### PR TITLE
Updates ViewState to include annotations

### DIFF
--- a/api/endpoints/ViewStateCollection_test.go
+++ b/api/endpoints/ViewStateCollection_test.go
@@ -239,6 +239,9 @@ func Example_viewStateHandler_GetCollection() {
 	//             "singleAxisRGBU": {},
 	//             "rgbuImages": {},
 	//             "parallelograms": {},
+	//             "annotations": {
+	//                 "savedAnnotations": []
+	//             },
 	//             "rois": {
 	//                 "roiColours": {},
 	//                 "roiShapes": {}
@@ -281,6 +284,9 @@ func Example_viewStateHandler_GetCollection() {
 	//             "singleAxisRGBU": {},
 	//             "rgbuImages": {},
 	//             "parallelograms": {},
+	//             "annotations": {
+	//                 "savedAnnotations": []
+	//             },
 	//             "rois": {
 	//                 "roiColours": {},
 	//                 "roiShapes": {}
@@ -335,6 +341,9 @@ func Example_viewStateHandler_GetCollection() {
 	//             "singleAxisRGBU": {},
 	//             "rgbuImages": {},
 	//             "parallelograms": {},
+	//             "annotations": {
+	//                 "savedAnnotations": []
+	//             },
 	//             "rois": {
 	//                 "roiColours": {},
 	//                 "roiShapes": {}
@@ -385,6 +394,9 @@ func Example_viewStateHandler_GetCollection() {
 	//             "singleAxisRGBU": {},
 	//             "rgbuImages": {},
 	//             "parallelograms": {},
+	//             "annotations": {
+	//                 "savedAnnotations": []
+	//             },
 	//             "rois": {
 	//                 "roiColours": {},
 	//                 "roiShapes": {}
@@ -466,6 +478,9 @@ func Example_viewStateHandler_GetCollectionShared() {
             "singleAxisRGBU": {},
             "rgbuImages": {},
             "parallelograms": {},
+            "annotations": {
+                "savedAnnotations": []
+            },
             "rois": {
                 "roiColours": {},
                 "roiShapes": {}
@@ -508,6 +523,9 @@ func Example_viewStateHandler_GetCollectionShared() {
             "singleAxisRGBU": {},
             "rgbuImages": {},
             "parallelograms": {},
+            "annotations": {
+                "savedAnnotations": []
+            },
             "rois": {
                 "roiColours": {},
 				"roiShapes": {}
@@ -585,6 +603,9 @@ func Example_viewStateHandler_GetCollectionShared() {
 	//             "singleAxisRGBU": {},
 	//             "rgbuImages": {},
 	//             "parallelograms": {},
+	//             "annotations": {
+	//                 "savedAnnotations": []
+	//             },
 	//             "rois": {
 	//                 "roiColours": {},
 	//                 "roiShapes": {}
@@ -627,6 +648,9 @@ func Example_viewStateHandler_GetCollectionShared() {
 	//             "singleAxisRGBU": {},
 	//             "rgbuImages": {},
 	//             "parallelograms": {},
+	//             "annotations": {
+	//                 "savedAnnotations": []
+	//             },
 	//             "rois": {
 	//                 "roiColours": {},
 	//                 "roiShapes": {}
@@ -928,6 +952,9 @@ func Example_viewStateHandler_ShareCollection() {
             "singleAxisRGBU": {},
             "rgbuImages": {},
             "parallelograms": {},
+            "annotations": {
+                "savedAnnotations": []
+            },
             "rois": {
                 "roiColours": {},
                 "roiShapes": {}
@@ -970,6 +997,9 @@ func Example_viewStateHandler_ShareCollection() {
             "singleAxisRGBU": {},
             "rgbuImages": {},
             "parallelograms": {},
+            "annotations": {
+                "savedAnnotations": []
+            },
             "rois": {
                 "roiColours": {},
                 "roiShapes": {}

--- a/api/endpoints/ViewStateModel.go
+++ b/api/endpoints/ViewStateModel.go
@@ -167,6 +167,27 @@ type contextImageState struct {
 	// PMCToolPMC int32 `json:"pmcToolPMC"`
 }
 
+type AnnotationPoint struct {
+	X            float32 `json:"x"`
+	Y            float32 `json:"y"`
+	ScreenWidth  float32 `json:"screenWidth"`
+	ScreenHeight float32 `json:"screenHeight"`
+}
+
+type FullScreenAnnotationItem struct {
+	Type     string            `json:"type"`
+	Points   []AnnotationPoint `json:"points"`
+	Colour   string            `json:"colour"`
+	Complete bool              `json:"complete"`
+	Text     string            `json:"text,omitempty"`
+	FontSize int               `json:"fontSize,omitempty"`
+	ID       int               `json:"id,omitempty"`
+}
+
+type annotationDisplayState struct {
+	SavedAnnotations []FullScreenAnnotationItem `json:"savedAnnotations"`
+}
+
 type roiDisplayState struct {
 	ROIColours map[string]string `json:"roiColours"`
 	ROIShapes  map[string]string `json:"roiShapes"`
@@ -225,6 +246,9 @@ type wholeViewState struct {
 	SingleAxisRGBU map[string]singleAxisRGBUWidgetState `json:"singleAxisRGBU"`
 	RGBUImageViews map[string]rgbuImagesWidgetState     `json:"rgbuImages"`
 	Parallelograms map[string]parallelogramWidgetState  `json:"parallelograms"`
+
+	// Full Screen Annotations
+	Annotations annotationDisplayState `json:"annotations"`
 
 	// Not strictly the view-state of a widget, but the shared display state of ROIs
 	// for the given user/dataset
@@ -365,6 +389,9 @@ func defaultWholeViewState() wholeViewState {
 	state.Spectrum = defaultSpectrum()
 
 	state.Selection = defaultSelectionState()
+
+	state.Annotations = annotationDisplayState{}
+	state.Annotations.SavedAnnotations = []FullScreenAnnotationItem{}
 
 	state.ROIs = roiDisplayState{}
 	state.ROIs.ROIColours = map[string]string{}

--- a/api/endpoints/ViewStateWorkspace_test.go
+++ b/api/endpoints/ViewStateWorkspace_test.go
@@ -444,6 +444,9 @@ func Example_viewStateHandler_GetSaved() {
 	//         "singleAxisRGBU": {},
 	//         "rgbuImages": {},
 	//         "parallelograms": {},
+	//         "annotations": {
+	//             "savedAnnotations": []
+	//         },
 	//         "rois": {
 	//             "roiColours": {
 	//                 "roi22": "rgba(128,0,255,0.5)",
@@ -573,6 +576,9 @@ func Example_viewStateHandler_GetSaved_ROIQuantFallbackCheck() {
 	//         "singleAxisRGBU": {},
 	//         "rgbuImages": {},
 	//         "parallelograms": {},
+	//         "annotations": {
+	//             "savedAnnotations": []
+	//         },
 	//         "rois": {
 	//             "roiColours": {
 	//                 "roi22": "rgba(128,0,255,0.5)",
@@ -696,6 +702,9 @@ func Example_viewStateHandler_GetSavedShared() {
 	//         "singleAxisRGBU": {},
 	//         "rgbuImages": {},
 	//         "parallelograms": {},
+	//         "annotations": {
+	//             "savedAnnotations": []
+	//         },
 	//         "rois": {
 	//             "roiColours": {
 	//                 "roi22": "rgba(128,0,255,0.5)",
@@ -756,6 +765,9 @@ func Example_viewStateHandler_PutSaved() {
         "singleAxisRGBU": {},
         "rgbuImages": {},
         "parallelograms": {},
+        "annotations": {
+            "savedAnnotations": []
+        },
         "rois": {
             "roiColours": {
                 "roi22": "rgba(128,0,255,0.5)",
@@ -915,6 +927,9 @@ func Example_viewStateHandler_RenamingWorkspaces() {
         "singleAxisRGBU": {},
         "rgbuImages": {},
         "parallelograms": {},
+        "annotations": {
+            "savedAnnotations": []
+        },
         "rois": {
             "roiColours": {},
             "roiShapes": {}
@@ -1703,6 +1718,9 @@ func Example_viewStateHandler_ShareViewState() {
         "singleAxisRGBU": {},
         "rgbuImages": {},
         "parallelograms": {},
+        "annotations": {
+            "savedAnnotations": []
+        },
         "rois": {
             "roiColours": {},
             "roiShapes": {}
@@ -2147,6 +2165,9 @@ func Example_viewStateHandler_ShareViewState_AutoShare() {
         "singleAxisRGBU": {},
         "rgbuImages": {},
         "parallelograms": {},
+        "annotations": {
+            "savedAnnotations": []
+        },
         "rois": {
             "roiColours": {},
             "roiShapes": {}

--- a/api/endpoints/ViewState_test.go
+++ b/api/endpoints/ViewState_test.go
@@ -509,6 +509,9 @@ func Example_viewStateHandler_List() {
 	//     "singleAxisRGBU": {},
 	//     "rgbuImages": {},
 	//     "parallelograms": {},
+	//     "annotations": {
+	//         "savedAnnotations": []
+	//     },
 	//     "rois": {
 	//         "roiColours": {
 	//             "roi22": "rgba(128,0,255,0.5)",
@@ -616,6 +619,9 @@ func Example_viewStateHandler_List_WithReset() {
 	//     "singleAxisRGBU": {},
 	//     "rgbuImages": {},
 	//     "parallelograms": {},
+	//     "annotations": {
+	//         "savedAnnotations": []
+	//     },
 	//     "rois": {
 	//         "roiColours": {},
 	//         "roiShapes": {}
@@ -1681,6 +1687,11 @@ func Example_viewStateHandler_Put_all() {
 	// NOTE: PUT expected JSON needs to have spaces not tabs
 	mockS3.ExpPutObjectInput = []s3.PutObjectInput{
 		{
+			Bucket: aws.String(UsersBucketForUnitTest), Key: aws.String(viewStateS3Path + "annotations.json"), Body: bytes.NewReader([]byte(`{
+    "savedAnnotations": []
+}`)),
+		},
+		{
 			Bucket: aws.String(UsersBucketForUnitTest), Key: aws.String(viewStateS3Path + "roi.json"), Body: bytes.NewReader([]byte(`{
     "roiColours": {
         "roi22": "rgba(128,0,255,0.5)",
@@ -2169,6 +2180,9 @@ func Example_viewStateHandler_Put_all() {
 		}
 	},
 	"parallelograms": {},
+	"annotations": {
+		"savedAnnotations": []
+	},
 	"rois": {
 		"roiColours": {
 			"roi22": "rgba(128,0,255,0.5)",


### PR DESCRIPTION
- Adds new types for annotations:
  - `annotationDisplayState`
    - Wrapper for annotation items
  - `FullScreenAnnotationItem`
    - JSONifiable wireframe of the FullScreenAnnotationItem equivalent in UI
  - `AnnotationPoint`
    - X/Y screen point with screen dimensions stored
- Updates view state tests