### PR TITLE
#1171: Fixing disco-only datasets, if no beam locations, we were fail…

### DIFF
--- a/data-import/data-converter/converter.go
+++ b/data-import/data-converter/converter.go
@@ -171,19 +171,6 @@ func ImportFromLocalFileSystem(
 	if err != nil {
 		return "", fmt.Errorf("Import failed: %v", err)
 	}
-	/*
-		// Apply any customisations/overrides:
-		if len(config.Name) > 1 { // 1 for spaces?
-			data.DatasetID = config.Name
-		}
-
-		overrideDetector := getOverrideDetectorForSol(data.Meta.SOL)
-		if len(overrideDetector) > 0 {
-			data.DetectorConfig = overrideDetector
-		}
-
-		data.Group = getDatasetGroup(data.DetectorConfig)
-	*/
 
 	// Apply any overrides we may have
 	customMetaFields, err := readLocalCustomMeta(log, localImportPath)

--- a/data-import/internal/data-converters/pixlfm/import.go
+++ b/data-import/internal/data-converters/pixlfm/import.go
@@ -337,7 +337,9 @@ func (p PIXLFM) Import(importPath string, pseudoIntensityRangesPath string, data
 	}
 
 	// Ensure it matches what we're expecting
-	if meta.RTT != datasetIDExpected {
+	// We allow for missing 0's at the start because for a while we imported RTTs as ints, so older dataset RTTs
+	// were coming in as eg 76481028, while we now read them as 076481028
+	if meta.RTT != datasetIDExpected && meta.RTT != "0"+datasetIDExpected {
 		return nil, "", fmt.Errorf("Expected dataset ID %v, read %v", datasetIDExpected, meta.RTT)
 	}
 

--- a/data-import/internal/importerutils/matchedImages.go
+++ b/data-import/internal/importerutils/matchedImages.go
@@ -61,9 +61,11 @@ func ReadMatchedImages(matchedPath string, beamLookup dataConvertModels.BeamLoca
 			return result, err
 		}
 
-		// Verify the images exist
-		if _, ok := beamLookup[meta.AlignedBeamPMC]; !ok {
-			return result, fmt.Errorf("Matched image %v references beam locations for PMC which cannot be found: %v", jsonPath, meta.AlignedBeamPMC)
+		// Verify the beams exist (though if we have NO beams, we're a "disco" dataset, so skip this)
+		if len(beamLookup) > 0 {
+			if _, ok := beamLookup[meta.AlignedBeamPMC]; !ok {
+				return result, fmt.Errorf("Matched image %v references beam locations for PMC which cannot be found: %v", jsonPath, meta.AlignedBeamPMC)
+			}
 		}
 
 		// Work out the full path, will be needed when copying to output dir


### PR DESCRIPTION
…ing to generate datasets with matched images. This fixes Gardes. Bellegarde also failed due to missing leading 0s in RTT