### PR TITLE
#2587 - include env name in db name when initing mongo (except on pro…

### DIFF
--- a/api/endpoints/Notification_test.go
+++ b/api/endpoints/Notification_test.go
@@ -51,7 +51,7 @@ func Test_subscription_get(t *testing.T) {
 	mockMongoResponses := []primitive.D{
 		mtest.CreateCursorResponse(
 			0,
-			"userdatabase.users",
+			"userdatabase-unit_test.users",
 			mtest.FirstBatch,
 			bson.D{
 				{"Userid", "600f2a0806b6c70071d3d174"},
@@ -89,7 +89,7 @@ func Test_subscriptions_get_empty_topics(t *testing.T) {
 	mockMongoResponses := []primitive.D{
 		mtest.CreateCursorResponse(
 			0,
-			"userdatabase.users",
+			"userdatabase-unit_test.users",
 			mtest.FirstBatch,
 			bson.D{
 				{"Userid", "600f2a0806b6c70071d3d174"},
@@ -115,12 +115,12 @@ func Test_subscriptions_get_no_user(t *testing.T) {
 	mockMongoResponses := []primitive.D{
 		mtest.CreateCursorResponse(
 			1,
-			"userdatabase.users",
+			"userdatabase-unit_test.users",
 			mtest.FirstBatch,
 		),
 		mtest.CreateCursorResponse(
 			0,
-			"userdatabase.users",
+			"userdatabase-unit_test.users",
 			mtest.NextBatch,
 		),
 	}
@@ -177,7 +177,7 @@ func Test_subscription_post(t *testing.T) {
 	mockMongoResponses := []primitive.D{
 		mtest.CreateCursorResponse(
 			1,
-			"userdatabase.users",
+			"userdatabase-unit_test.users",
 			mtest.FirstBatch,
 			bson.D{
 				{"Userid", "600f2a0806b6c70071d3d174"},
@@ -249,12 +249,12 @@ func Test_subscription_post_no_user(t *testing.T) {
 		// Signify no user exists...
 		mtest.CreateCursorResponse(
 			1,
-			"userdatabase.users",
+			"userdatabase-unit_test.users",
 			mtest.FirstBatch,
 		),
 		mtest.CreateCursorResponse(
 			0,
-			"userdatabase.users",
+			"userdatabase-unit_test.users",
 			mtest.NextBatch,
 		),
 		// User saved
@@ -286,7 +286,7 @@ func Test_alerts_get(t *testing.T) {
 		// Get user request
 		mtest.CreateCursorResponse(
 			1,
-			"userdatabase.notifications",
+			"userdatabase-unit_test.notifications",
 			mtest.FirstBatch,
 			bson.D{
 				{"Topic", "test-data-source"},
@@ -297,7 +297,7 @@ func Test_alerts_get(t *testing.T) {
 		),
 		mtest.CreateCursorResponse(
 			0,
-			"userdatabase.notifications",
+			"userdatabase-unit_test.notifications",
 			mtest.NextBatch,
 			bson.D{
 				{"Topic", "test-data-source"},
@@ -344,7 +344,7 @@ func Test_hints_post(t *testing.T) {
 		// Get user
 		mtest.CreateCursorResponse(
 			1,
-			"userdatabase.users",
+			"userdatabase-unit_test.users",
 			mtest.FirstBatch,
 			bson.D{
 				{"Userid", "600f2a0806b6c70071d3d174"},
@@ -386,12 +386,12 @@ func Test_hints_post_no_user(t *testing.T) {
 		// Get user (none)
 		mtest.CreateCursorResponse(
 			1,
-			"userdatabase.users",
+			"userdatabase-unit_test.users",
 			mtest.FirstBatch,
 		),
 		mtest.CreateCursorResponse(
 			0,
-			"userdatabase.users",
+			"userdatabase-unit_test.users",
 			mtest.NextBatch,
 		),
 		// Write user
@@ -407,12 +407,12 @@ func makeNotFoundMongoResponse() []primitive.D {
 	return []primitive.D{
 		mtest.CreateCursorResponse(
 			1,
-			"userdatabase.notifications",
+			"userdatabase-unit_test.notifications",
 			mtest.FirstBatch,
 		),
 		mtest.CreateCursorResponse(
 			0,
-			"userdatabase.notifications",
+			"userdatabase-unit_test.notifications",
 			mtest.NextBatch,
 		),
 	}
@@ -430,7 +430,7 @@ func runOneURLCallTest(t *testing.T, method string, url string, requestPayload i
 
 		svcs := MakeMockSvcs(&mockS3, nil, nil, nil)
 		setTestAuth0Config(&svcs)
-		notifications, err := notifications.MakeNotificationStack(mt.Client, nil, &logger.StdOutLoggerForTest{}, []string{})
+		notifications, err := notifications.MakeNotificationStack(mt.Client, "unit_test", nil, &logger.StdOutLoggerForTest{}, []string{})
 		if err != nil {
 			t.Error(err)
 		}

--- a/api/endpoints/UserManagement_test.go
+++ b/api/endpoints/UserManagement_test.go
@@ -230,7 +230,7 @@ func Test_user_config_get(t *testing.T) {
 	mockMongoResponses := []primitive.D{
 		mtest.CreateCursorResponse(
 			0,
-			"userdatabase.users",
+			"userdatabase-unit_test.users",
 			mtest.FirstBatch,
 			bson.D{
 				{"Userid", "600f2a0806b6c70071d3d174"},
@@ -274,7 +274,7 @@ func Test_user_config_post(t *testing.T) {
 		// User read
 		mtest.CreateCursorResponse(
 			0,
-			"userdatabase.users",
+			"userdatabase-unit_test.users",
 			mtest.FirstBatch,
 			bson.D{
 				{"Userid", "600f2a0806b6c70071d3d174"},

--- a/api/endpoints/ViewState_test.go
+++ b/api/endpoints/ViewState_test.go
@@ -795,7 +795,7 @@ func Test_viewStateHandler_Put_spectrum_topright_AND_middleware_activity_logging
 
 		setTestAuth0Config(&svcs)
 
-		notifications, err := notifications.MakeNotificationStack(mt.Client, nil, &logger.StdOutLoggerForTest{}, []string{})
+		notifications, err := notifications.MakeNotificationStack(mt.Client, "unit_test", nil, &logger.StdOutLoggerForTest{}, []string{})
 		if err != nil {
 			t.Error(err)
 		}

--- a/api/endpoints/middlewareLogger_test.go
+++ b/api/endpoints/middlewareLogger_test.go
@@ -66,7 +66,7 @@ func runMiddlewareLoggingTest(t *testing.T, logLevel *logger.LogLevel) {
 			QueuedTimeStamps: []int64{1668142579},
 		}
 
-		notifications, err := notifications.MakeNotificationStack(mt.Client, nil, &logger.StdOutLoggerForTest{}, []string{})
+		notifications, err := notifications.MakeNotificationStack(mt.Client, "unit_test", nil, &logger.StdOutLoggerForTest{}, []string{})
 		if err != nil {
 			t.Error(err)
 		}

--- a/core/notifications/notificationStack.go
+++ b/core/notifications/notificationStack.go
@@ -47,8 +47,13 @@ type NotificationStack struct {
 	log logger.ILogger
 }
 
-func MakeNotificationStack(mongoClient *mongo.Client, timestamper timestamper.ITimeStamper, log logger.ILogger, adminEmails []string) (*NotificationStack, error) {
-	userDatabase := mongoClient.Database("userdatabase")
+func MakeNotificationStack(mongoClient *mongo.Client, envName string, timestamper timestamper.ITimeStamper, log logger.ILogger, adminEmails []string) (*NotificationStack, error) {
+	userDatabaseName := "userdatabase"
+	if envName != "prod" {
+		userDatabaseName += "-" + envName
+	}
+
+	userDatabase := mongoClient.Database(userDatabaseName)
 	userCollection := userDatabase.Collection("users")
 	notificationCollection := userDatabase.Collection("notifications")
 

--- a/internal/pixlise-api/apiMain.go
+++ b/internal/pixlise-api/apiMain.go
@@ -125,7 +125,7 @@ func main() {
 	svcs.Log.Infof(cfgStr)
 
 	// Reinitialised because of dependency on S3
-	notificationStack, err := notifications.MakeNotificationStack(svcs.Mongo, svcs.TimeStamper, svcs.Log, cfg.AdminEmails)
+	notificationStack, err := notifications.MakeNotificationStack(svcs.Mongo, cfg.EnvironmentName, svcs.TimeStamper, svcs.Log, cfg.AdminEmails)
 
 	if err != nil {
 		err2 := fmt.Errorf("Failed to create notification stack: %v", err)


### PR DESCRIPTION
…d so we use what's already there, called userdatabase). Elsewhere it'd be eg userdatabase-dev