### PR TITLE
#1184: Added created and modified unix time stamps (in seconds) to ou…

### DIFF
--- a/api/endpoints/DataExpression_test.go
+++ b/api/endpoints/DataExpression_test.go
@@ -28,6 +28,7 @@ import (
 	"github.com/aws/aws-sdk-go/service/s3"
 	"github.com/pixlise/core/v2/core/awsutil"
 	"github.com/pixlise/core/v2/core/pixlUser"
+	"github.com/pixlise/core/v2/core/timestamper"
 	"go.mongodb.org/mongo-driver/bson"
 	"go.mongodb.org/mongo-driver/bson/primitive"
 	"go.mongodb.org/mongo-driver/mongo/integration/mtest"
@@ -45,7 +46,9 @@ const exprFile = `{
 			"user_id": "999",
 			"name": "Peter N",
             "email": "niko@spicule.co.uk"
-		}
+		},
+        "create_unix_time_sec": 1668100000,
+        "mod_unix_time_sec": 1668100000
 	},
 	"def456": {
 		"name": "Iron Error",
@@ -56,7 +59,9 @@ const exprFile = `{
 			"user_id": "999",
 			"name": "Peter N",
             "email": "niko@spicule.co.uk"
-		}
+		},
+        "create_unix_time_sec": 1668100001,
+        "mod_unix_time_sec": 1668100001
 	}
 }`
 
@@ -169,7 +174,9 @@ func Test_dataExpressionHandler_List(t *testing.T) {
             "name": "Peter N",
             "user_id": "999",
             "email": "peter@spicule.co.uk"
-        }
+        },
+        "create_unix_time_sec": 1668100000,
+        "mod_unix_time_sec": 1668100000
     },
     "def456": {
         "name": "Iron Error",
@@ -181,7 +188,9 @@ func Test_dataExpressionHandler_List(t *testing.T) {
             "name": "Peter N",
             "user_id": "999",
             "email": "peter@spicule.co.uk"
-        }
+        },
+        "create_unix_time_sec": 1668100001,
+        "mod_unix_time_sec": 1668100001
     },
     "shared-ghi789": {
         "name": "Iron %",
@@ -256,7 +265,9 @@ func Example_dataExpressionHandler_Post() {
             "name": "Niko Bellic",
             "user_id": "600f2a0806b6c70071d3d174",
             "email": "niko@spicule.co.uk"
-        }
+        },
+        "create_unix_time_sec": 1668142579,
+        "mod_unix_time_sec": 1668142579
     }
 }`)),
 		},
@@ -272,7 +283,9 @@ func Example_dataExpressionHandler_Post() {
             "name": "Niko Bellic",
             "user_id": "600f2a0806b6c70071d3d174",
             "email": "niko@spicule.co.uk"
-        }
+        },
+        "create_unix_time_sec": 1668142580,
+        "mod_unix_time_sec": 1668142580
     }
 }`)),
 		},
@@ -288,7 +301,9 @@ func Example_dataExpressionHandler_Post() {
             "name": "Peter N",
             "user_id": "999",
             "email": "niko@spicule.co.uk"
-        }
+        },
+        "create_unix_time_sec": 1668100000,
+        "mod_unix_time_sec": 1668100000
     },
     "def456": {
         "name": "Iron Error",
@@ -300,7 +315,9 @@ func Example_dataExpressionHandler_Post() {
             "name": "Peter N",
             "user_id": "999",
             "email": "niko@spicule.co.uk"
-        }
+        },
+        "create_unix_time_sec": 1668100001,
+        "mod_unix_time_sec": 1668100001
     },
     "id18": {
         "name": "Sodium weight%",
@@ -312,7 +329,9 @@ func Example_dataExpressionHandler_Post() {
             "name": "Niko Bellic",
             "user_id": "600f2a0806b6c70071d3d174",
             "email": "niko@spicule.co.uk"
-        }
+        },
+        "create_unix_time_sec": 1668142581,
+        "mod_unix_time_sec": 1668142581
     }
 }`)),
 		},
@@ -326,6 +345,9 @@ func Example_dataExpressionHandler_Post() {
 	var idGen MockIDGenerator
 	idGen.ids = []string{"id16", "id17", "id18"}
 	svcs := MakeMockSvcs(&mockS3, &idGen, nil, nil)
+	svcs.TimeStamper = &timestamper.MockTimeNowStamper{
+		QueuedTimeStamps: []int64{1668142579, 1668142580, 1668142581},
+	}
 	apiRouter := MakeRouter(svcs)
 
 	const putItem = `{
@@ -369,7 +391,9 @@ func Example_dataExpressionHandler_Post() {
 	//             "name": "Niko Bellic",
 	//             "user_id": "600f2a0806b6c70071d3d174",
 	//             "email": "niko@spicule.co.uk"
-	//         }
+	//         },
+	//         "create_unix_time_sec": 1668142579,
+	//         "mod_unix_time_sec": 1668142579
 	//     }
 	// }
 	//
@@ -385,7 +409,9 @@ func Example_dataExpressionHandler_Post() {
 	//             "name": "Niko Bellic",
 	//             "user_id": "600f2a0806b6c70071d3d174",
 	//             "email": "niko@spicule.co.uk"
-	//         }
+	//         },
+	//         "create_unix_time_sec": 1668142580,
+	//         "mod_unix_time_sec": 1668142580
 	//     }
 	// }
 	//
@@ -401,7 +427,9 @@ func Example_dataExpressionHandler_Post() {
 	//             "name": "Peter N",
 	//             "user_id": "999",
 	//             "email": "niko@spicule.co.uk"
-	//         }
+	//         },
+	//         "create_unix_time_sec": 1668100000,
+	//         "mod_unix_time_sec": 1668100000
 	//     },
 	//     "def456": {
 	//         "name": "Iron Error",
@@ -413,7 +441,9 @@ func Example_dataExpressionHandler_Post() {
 	//             "name": "Peter N",
 	//             "user_id": "999",
 	//             "email": "niko@spicule.co.uk"
-	//         }
+	//         },
+	//         "create_unix_time_sec": 1668100001,
+	//         "mod_unix_time_sec": 1668100001
 	//     },
 	//     "id18": {
 	//         "name": "Sodium weight%",
@@ -425,7 +455,9 @@ func Example_dataExpressionHandler_Post() {
 	//             "name": "Niko Bellic",
 	//             "user_id": "600f2a0806b6c70071d3d174",
 	//             "email": "niko@spicule.co.uk"
-	//         }
+	//         },
+	//         "create_unix_time_sec": 1668142581,
+	//         "mod_unix_time_sec": 1668142581
 	//     }
 	// }
 }
@@ -475,7 +507,9 @@ func Example_dataExpressionHandler_Put() {
             "name": "Peter N",
             "user_id": "999",
             "email": "niko@spicule.co.uk"
-        }
+        },
+        "create_unix_time_sec": 1668100000,
+        "mod_unix_time_sec": 1668100000
     },
     "def456": {
         "name": "Iron Int",
@@ -487,7 +521,9 @@ func Example_dataExpressionHandler_Put() {
             "name": "Peter N",
             "user_id": "999",
             "email": "niko@spicule.co.uk"
-        }
+        },
+        "create_unix_time_sec": 1668100001,
+        "mod_unix_time_sec": 1668142579
     }
 }`)),
 		},
@@ -497,6 +533,9 @@ func Example_dataExpressionHandler_Put() {
 	}
 
 	svcs := MakeMockSvcs(&mockS3, nil, nil, nil)
+	svcs.TimeStamper = &timestamper.MockTimeNowStamper{
+		QueuedTimeStamps: []int64{1668142579},
+	}
 	apiRouter := MakeRouter(svcs)
 
 	const putItem = `{
@@ -560,7 +599,9 @@ func Example_dataExpressionHandler_Put() {
 	//             "name": "Peter N",
 	//             "user_id": "999",
 	//             "email": "niko@spicule.co.uk"
-	//         }
+	//         },
+	//         "create_unix_time_sec": 1668100000,
+	//         "mod_unix_time_sec": 1668100000
 	//     },
 	//     "def456": {
 	//         "name": "Iron Int",
@@ -572,7 +613,9 @@ func Example_dataExpressionHandler_Put() {
 	//             "name": "Peter N",
 	//             "user_id": "999",
 	//             "email": "niko@spicule.co.uk"
-	//         }
+	//         },
+	//         "create_unix_time_sec": 1668100001,
+	//         "mod_unix_time_sec": 1668142579
 	//     }
 	// }
 	//
@@ -652,7 +695,9 @@ func Example_dataExpressionHandler_Delete() {
             "name": "Peter N",
             "user_id": "999",
             "email": "niko@spicule.co.uk"
-        }
+        },
+        "create_unix_time_sec": 1668100001,
+        "mod_unix_time_sec": 1668100001
     }
 }`)),
 		},
@@ -732,7 +777,9 @@ func Example_dataExpressionHandler_Delete() {
 	//             "name": "Peter N",
 	//             "user_id": "999",
 	//             "email": "niko@spicule.co.uk"
-	//         }
+	//         },
+	//         "create_unix_time_sec": 1668100001,
+	//         "mod_unix_time_sec": 1668100001
 	//     }
 	// }
 	//
@@ -755,7 +802,9 @@ func Example_dataExpressionHandler_Share() {
 				"name": "The sharer",
 				"user_id": "600f2a0806b6c70071d3d174",
 				"email": "niko@spicule.co.uk"
-			}
+			},
+			"create_unix_time_sec": 1668150001,
+			"mod_unix_time_sec": 1668150001
 		}
 	}`
 	var mockS3 awsutil.MockS3Client
@@ -829,7 +878,9 @@ func Example_dataExpressionHandler_Share() {
             "name": "The sharer",
             "user_id": "600f2a0806b6c70071d3d174",
             "email": "niko@spicule.co.uk"
-        }
+        },
+        "create_unix_time_sec": 1668150001,
+        "mod_unix_time_sec": 1668150001
     },
     "ddd222": {
         "name": "Iron Error",
@@ -841,7 +892,9 @@ func Example_dataExpressionHandler_Share() {
             "name": "Peter N",
             "user_id": "999",
             "email": "niko@spicule.co.uk"
-        }
+        },
+        "create_unix_time_sec": 1668100001,
+        "mod_unix_time_sec": 1668142579
     }
 }`)),
 		},
@@ -853,6 +906,9 @@ func Example_dataExpressionHandler_Share() {
 	var idGen MockIDGenerator
 	idGen.ids = []string{"ddd222"}
 	svcs := MakeMockSvcs(&mockS3, &idGen, nil, nil)
+	svcs.TimeStamper = &timestamper.MockTimeNowStamper{
+		QueuedTimeStamps: []int64{1668142579},
+	}
 	apiRouter := MakeRouter(svcs)
 
 	const putItem = ""

--- a/api/endpoints/ElementSet_test.go
+++ b/api/endpoints/ElementSet_test.go
@@ -28,6 +28,7 @@ import (
 	"github.com/aws/aws-sdk-go/service/s3"
 	"github.com/pixlise/core/v2/core/awsutil"
 	"github.com/pixlise/core/v2/core/pixlUser"
+	"github.com/pixlise/core/v2/core/timestamper"
 	"go.mongodb.org/mongo-driver/bson"
 	"go.mongodb.org/mongo-driver/bson/primitive"
 	"go.mongodb.org/mongo-driver/mongo/integration/mtest"
@@ -54,7 +55,9 @@ const elemFile = `{
 				"Esc": false
 			}
 		],
-		"creator": { "name": "Peter", "user_id": "u123" }
+		"creator": { "name": "Peter", "user_id": "u123" },
+        "create_unix_time_sec": 1668100000,
+        "mod_unix_time_sec": 1668100000
 	},
 	"44": {
 		"name": "My Tuesday Elements",
@@ -74,7 +77,9 @@ const elemFile = `{
 				"Esc": false
 			}
 		],
-		"creator": { "name": "Tom", "user_id": "u124" }
+		"creator": { "name": "Tom", "user_id": "u124" },
+        "create_unix_time_sec": 1668100001,
+        "mod_unix_time_sec": 1668100001
 	}
 }`
 
@@ -176,7 +181,9 @@ func Test_elementSetHandler_List(t *testing.T) {
 					"Esc": false
 				}
 			],
-			"creator": { "name": "Peter", "user_id": "u123" }
+			"creator": { "name": "Peter", "user_id": "u123" },
+			"create_unix_time_sec": 1668100002,
+			"mod_unix_time_sec": 1668100002
 		}
 	}`))),
 			},
@@ -193,7 +200,9 @@ func Test_elementSetHandler_List(t *testing.T) {
 					"Esc": false
 				}
 			],
-			"creator": { "name": "Mike", "user_id": "u125" }
+			"creator": { "name": "Mike", "user_id": "u125" },
+			"create_unix_time_sec": 1668100003,
+			"mod_unix_time_sec": 1668100003
 		}
 	}`))),
 			},
@@ -230,7 +239,9 @@ func Test_elementSetHandler_List(t *testing.T) {
             "name": "Peter",
             "user_id": "u123",
             "email": ""
-        }
+        },
+        "create_unix_time_sec": 1668100002,
+        "mod_unix_time_sec": 1668100002
     },
     "shared-88": {
         "name": "Shared Elements",
@@ -242,7 +253,9 @@ func Test_elementSetHandler_List(t *testing.T) {
             "name": "Mike T",
             "user_id": "u125",
             "email": "mike@spicule.co.uk"
-        }
+        },
+        "create_unix_time_sec": 1668100003,
+        "mod_unix_time_sec": 1668100003
     }
 }
 `)
@@ -365,7 +378,9 @@ func Test_elementSetHandler_Get(t *testing.T) {
         "name": "Peter N",
         "user_id": "u123",
         "email": ""
-    }
+    },
+    "create_unix_time_sec": 1668100000,
+    "mod_unix_time_sec": 1668100000
 }
 `)
 
@@ -396,7 +411,9 @@ func Test_elementSetHandler_Get(t *testing.T) {
         "name": "Peter N",
         "user_id": "u123",
         "email": ""
-    }
+    },
+    "create_unix_time_sec": 1668100000,
+    "mod_unix_time_sec": 1668100000
 }
 `)
 	})
@@ -445,7 +462,9 @@ func Example_elementSetHandler_Post() {
             "name": "Niko Bellic",
             "user_id": "600f2a0806b6c70071d3d174",
             "email": "niko@spicule.co.uk"
-        }
+        },
+        "create_unix_time_sec": 1668142579,
+        "mod_unix_time_sec": 1668142579
     }
 }`)),
 		},
@@ -467,7 +486,9 @@ func Example_elementSetHandler_Post() {
             "name": "Niko Bellic",
             "user_id": "600f2a0806b6c70071d3d174",
             "email": "niko@spicule.co.uk"
-        }
+        },
+        "create_unix_time_sec": 1668142580,
+        "mod_unix_time_sec": 1668142580
     }
 }`)),
 		},
@@ -496,7 +517,9 @@ func Example_elementSetHandler_Post() {
             "name": "Peter",
             "user_id": "u123",
             "email": ""
-        }
+        },
+        "create_unix_time_sec": 1668100000,
+        "mod_unix_time_sec": 1668100000
     },
     "44": {
         "name": "My Tuesday Elements",
@@ -521,7 +544,9 @@ func Example_elementSetHandler_Post() {
             "name": "Tom",
             "user_id": "u124",
             "email": ""
-        }
+        },
+        "create_unix_time_sec": 1668100001,
+        "mod_unix_time_sec": 1668100001
     },
     "57": {
         "name": "Latest set",
@@ -539,7 +564,9 @@ func Example_elementSetHandler_Post() {
             "name": "Niko Bellic",
             "user_id": "600f2a0806b6c70071d3d174",
             "email": "niko@spicule.co.uk"
-        }
+        },
+        "create_unix_time_sec": 1668142581,
+        "mod_unix_time_sec": 1668142581
     }
 }`)),
 		},
@@ -553,6 +580,9 @@ func Example_elementSetHandler_Post() {
 	var idGen MockIDGenerator
 	idGen.ids = []string{"55", "56", "57"}
 	svcs := MakeMockSvcs(&mockS3, &idGen, nil, nil)
+	svcs.TimeStamper = &timestamper.MockTimeNowStamper{
+		QueuedTimeStamps: []int64{1668142579, 1668142580, 1668142581},
+	}
 	apiRouter := MakeRouter(svcs)
 
 	const postItem = `{
@@ -653,7 +683,9 @@ func Example_elementSetHandler_Put() {
             "name": "Peter",
             "user_id": "u123",
             "email": ""
-        }
+        },
+        "create_unix_time_sec": 1668100000,
+        "mod_unix_time_sec": 1668100000
     },
     "44": {
         "name": "Latest set",
@@ -671,7 +703,9 @@ func Example_elementSetHandler_Put() {
             "name": "Tom",
             "user_id": "u124",
             "email": ""
-        }
+        },
+        "create_unix_time_sec": 1668100001,
+        "mod_unix_time_sec": 1668142579
     }
 }`)),
 		},
@@ -681,6 +715,9 @@ func Example_elementSetHandler_Put() {
 	}
 
 	svcs := MakeMockSvcs(&mockS3, nil, nil, nil)
+	svcs.TimeStamper = &timestamper.MockTimeNowStamper{
+		QueuedTimeStamps: []int64{1668142579},
+	}
 	apiRouter := MakeRouter(svcs)
 
 	const putItem = `{
@@ -833,7 +870,9 @@ func Example_elementSetHandler_Delete() {
             "name": "Tom",
             "user_id": "u124",
             "email": ""
-        }
+        },
+        "create_unix_time_sec": 1668100001,
+        "mod_unix_time_sec": 1668100001
     }
 }`)),
 		},
@@ -1008,7 +1047,9 @@ func Example_elementSetHandler_Share() {
             "name": "Tom",
             "user_id": "u124",
             "email": ""
-        }
+        },
+        "create_unix_time_sec": 1668100001,
+        "mod_unix_time_sec": 1668100001
     }
 }`)),
 		},

--- a/api/endpoints/RGBMix_test.go
+++ b/api/endpoints/RGBMix_test.go
@@ -28,6 +28,7 @@ import (
 	"github.com/aws/aws-sdk-go/service/s3"
 	"github.com/pixlise/core/v2/core/awsutil"
 	"github.com/pixlise/core/v2/core/pixlUser"
+	"github.com/pixlise/core/v2/core/timestamper"
 	"go.mongodb.org/mongo-driver/bson"
 	"go.mongodb.org/mongo-driver/bson/primitive"
 	"go.mongodb.org/mongo-driver/mongo/integration/mtest"
@@ -57,7 +58,9 @@ const rgbMixFileData = `{
 			"user_id": "999",
 			"name": "Peter N",
             "email": "niko@spicule.co.uk"
-		}
+		},
+        "create_unix_time_sec": 1668100000,
+        "mod_unix_time_sec": 1668100000
 	},
 	"def456": {
 		"name": "Ca-Fe-Al ratios",
@@ -80,7 +83,9 @@ const rgbMixFileData = `{
 			"user_id": "999",
 			"name": "Peter N",
             "email": "niko@spicule.co.uk"
-		}
+		},
+        "create_unix_time_sec": 1668100001,
+        "mod_unix_time_sec": 1668100001
 	}
 }`
 
@@ -193,7 +198,9 @@ func Test_RGBMixHandler_List(t *testing.T) {
 				"user_id": "88",
 				"name": "88",
 				"email": "mr88@spicule.co.uk"
-			}
+			},
+			"create_unix_time_sec": 1668100002,
+			"mod_unix_time_sec": 1668100002
 		}
 	}`))),
 			},
@@ -241,7 +248,9 @@ func Test_RGBMixHandler_List(t *testing.T) {
             "name": "Peter N",
             "user_id": "999",
             "email": "niko@spicule.co.uk"
-        }
+        },
+        "create_unix_time_sec": 1668100000,
+        "mod_unix_time_sec": 1668100000
     },
     "def456": {
         "name": "Ca-Fe-Al ratios",
@@ -265,7 +274,9 @@ func Test_RGBMixHandler_List(t *testing.T) {
             "name": "Peter N",
             "user_id": "999",
             "email": "niko@spicule.co.uk"
-        }
+        },
+        "create_unix_time_sec": 1668100001,
+        "mod_unix_time_sec": 1668100001
     },
     "shared-ghi789": {
         "name": "Na-Fe-Al ratios",
@@ -289,7 +300,9 @@ func Test_RGBMixHandler_List(t *testing.T) {
             "name": "Agent 88",
             "user_id": "88",
             "email": "agent_88@spicule.co.uk"
-        }
+        },
+        "create_unix_time_sec": 1668100002,
+        "mod_unix_time_sec": 1668100002
     }
 }
 `)
@@ -364,7 +377,9 @@ func Example_RGBMixHandler_Post() {
             "name": "Niko Bellic",
             "user_id": "600f2a0806b6c70071d3d174",
             "email": "niko@spicule.co.uk"
-        }
+        },
+        "create_unix_time_sec": 1668142579,
+        "mod_unix_time_sec": 1668142579
     }
 }`)),
 		},
@@ -392,7 +407,9 @@ func Example_RGBMixHandler_Post() {
             "name": "Niko Bellic",
             "user_id": "600f2a0806b6c70071d3d174",
             "email": "niko@spicule.co.uk"
-        }
+        },
+        "create_unix_time_sec": 1668142580,
+        "mod_unix_time_sec": 1668142580
     }
 }`)),
 		},
@@ -420,7 +437,9 @@ func Example_RGBMixHandler_Post() {
             "name": "Peter N",
             "user_id": "999",
             "email": "niko@spicule.co.uk"
-        }
+        },
+        "create_unix_time_sec": 1668100000,
+        "mod_unix_time_sec": 1668100000
     },
     "def456": {
         "name": "Ca-Fe-Al ratios",
@@ -444,7 +463,9 @@ func Example_RGBMixHandler_Post() {
             "name": "Peter N",
             "user_id": "999",
             "email": "niko@spicule.co.uk"
-        }
+        },
+        "create_unix_time_sec": 1668100001,
+        "mod_unix_time_sec": 1668100001
     },
     "rgbmix-id18": {
         "name": "Sodium and stuff",
@@ -468,7 +489,9 @@ func Example_RGBMixHandler_Post() {
             "name": "Niko Bellic",
             "user_id": "600f2a0806b6c70071d3d174",
             "email": "niko@spicule.co.uk"
-        }
+        },
+        "create_unix_time_sec": 1668142581,
+        "mod_unix_time_sec": 1668142581
     }
 }`)),
 		},
@@ -482,6 +505,9 @@ func Example_RGBMixHandler_Post() {
 	var idGen MockIDGenerator
 	idGen.ids = []string{"id16", "id17", "id18"}
 	svcs := MakeMockSvcs(&mockS3, &idGen, nil, nil)
+	svcs.TimeStamper = &timestamper.MockTimeNowStamper{
+		QueuedTimeStamps: []int64{1668142579, 1668142580, 1668142581},
+	}
 	apiRouter := MakeRouter(svcs)
 
 	const putItem = `{
@@ -617,7 +643,9 @@ func Example_RGBMixHandler_Put() {
             "name": "Peter N",
             "user_id": "999",
             "email": "niko@spicule.co.uk"
-        }
+        },
+        "create_unix_time_sec": 1668100000,
+        "mod_unix_time_sec": 1668100000
     },
     "def456": {
         "name": "Sodium and stuff",
@@ -641,7 +669,9 @@ func Example_RGBMixHandler_Put() {
             "name": "Peter N",
             "user_id": "999",
             "email": "niko@spicule.co.uk"
-        }
+        },
+        "create_unix_time_sec": 1668100001,
+        "mod_unix_time_sec": 1668142579
     }
 }`)),
 		},
@@ -651,6 +681,9 @@ func Example_RGBMixHandler_Put() {
 	}
 
 	svcs := MakeMockSvcs(&mockS3, nil, nil, nil)
+	svcs.TimeStamper = &timestamper.MockTimeNowStamper{
+		QueuedTimeStamps: []int64{1668142579},
+	}
 	apiRouter := MakeRouter(svcs)
 
 	const putItem = `{
@@ -785,7 +818,9 @@ func Example_RGBMixHandler_Delete() {
             "name": "The sharer",
             "user_id": "600f2a0806b6c70071d3d174",
             "email": "niko@spicule.co.uk"
-        }
+        },
+        "create_unix_time_sec": 1668100001,
+        "mod_unix_time_sec": 1668100001
     }
 }`))),
 		},
@@ -816,7 +851,9 @@ func Example_RGBMixHandler_Delete() {
             "name": "Peter N",
             "user_id": "999",
             "email": "niko@spicule.co.uk"
-        }
+        },
+        "create_unix_time_sec": 1668100001,
+        "mod_unix_time_sec": 1668100001
     }
 }`)),
 		},
@@ -949,7 +986,9 @@ func Example_RGBMixHandler_Share() {
             "name": "The sharer",
             "user_id": "600f2a0806b6c70071d3d174",
             "email": "niko@spicule.co.uk"
-        }
+        },
+        "create_unix_time_sec": 1668100006,
+        "mod_unix_time_sec": 1668100006
     }
 }`))),
 		},
@@ -980,7 +1019,9 @@ func Example_RGBMixHandler_Share() {
             "name": "The sharer",
             "user_id": "600f2a0806b6c70071d3d174",
             "email": "niko@spicule.co.uk"
-        }
+        },
+        "create_unix_time_sec": 1668100006,
+        "mod_unix_time_sec": 1668100006
     },
     "rgbmix-ddd222": {
         "name": "Ca-Fe-Al ratios",
@@ -1004,7 +1045,9 @@ func Example_RGBMixHandler_Share() {
             "name": "Peter N",
             "user_id": "999",
             "email": "niko@spicule.co.uk"
-        }
+        },
+        "create_unix_time_sec": 1668100001,
+        "mod_unix_time_sec": 1668142579
     }
 }`)),
 		},
@@ -1016,6 +1059,9 @@ func Example_RGBMixHandler_Share() {
 	var idGen MockIDGenerator
 	idGen.ids = []string{"ddd222"}
 	svcs := MakeMockSvcs(&mockS3, &idGen, nil, nil)
+	svcs.TimeStamper = &timestamper.MockTimeNowStamper{
+		QueuedTimeStamps: []int64{1668142579},
+	}
 	apiRouter := MakeRouter(svcs)
 
 	const putItem = ""

--- a/api/endpoints/ROI.go
+++ b/api/endpoints/ROI.go
@@ -124,6 +124,7 @@ func createROIs(params handlers.ApiHandlerParams, rois []roiModel.ROIItem, overw
 		}
 	}
 
+	timeNow := params.Svcs.TimeStamper.GetTimeNowSec()
 	for i := range rois {
 		// Validate
 		if !fileaccess.IsValidObjectName(rois[i].Name) {
@@ -161,8 +162,10 @@ func createROIs(params handlers.ApiHandlerParams, rois []roiModel.ROIItem, overw
 		allROIs[saveID] = roiModel.ROISavedItem{
 			ROIItem: &rois[i],
 			APIObjectItem: &pixlUser.APIObjectItem{
-				Shared:  false,
-				Creator: params.UserInfo,
+				Shared:              false,
+				Creator:             params.UserInfo,
+				CreatedUnixTimeSec:  timeNow,
+				ModifiedUnixTimeSec: timeNow,
 			},
 		}
 	}
@@ -257,7 +260,7 @@ func roiPut(params handlers.ApiHandlerParams) (interface{}, error) {
 		}
 
 		// Check that it exists
-		_, exists := allROIs[rois[i].ID]
+		existing, exists := allROIs[rois[i].ID]
 		if !exists {
 			return nil, api.MakeStatusError(http.StatusNotFound, fmt.Errorf("roi %v not found", rois[i].ID))
 		}
@@ -265,8 +268,10 @@ func roiPut(params handlers.ApiHandlerParams) (interface{}, error) {
 		allROIs[rois[i].ID] = roiModel.ROISavedItem{
 			ROIItem: &rois[i].ROI,
 			APIObjectItem: &pixlUser.APIObjectItem{
-				Shared:  false,
-				Creator: params.UserInfo,
+				Shared:              false,
+				Creator:             params.UserInfo,
+				CreatedUnixTimeSec:  existing.CreatedUnixTimeSec,
+				ModifiedUnixTimeSec: params.Svcs.TimeStamper.GetTimeNowSec(),
 			},
 		}
 	}

--- a/api/endpoints/ROI_test.go
+++ b/api/endpoints/ROI_test.go
@@ -28,6 +28,7 @@ import (
 	"github.com/aws/aws-sdk-go/service/s3"
 	"github.com/pixlise/core/v2/core/awsutil"
 	"github.com/pixlise/core/v2/core/pixlUser"
+	"github.com/pixlise/core/v2/core/timestamper"
 	"go.mongodb.org/mongo-driver/bson"
 	"go.mongodb.org/mongo-driver/bson/primitive"
 	"go.mongodb.org/mongo-driver/mongo/integration/mtest"
@@ -41,6 +42,8 @@ const roi2XItems = `{
         "description": "The second dark patch",
         "locationIndexes": [4, 55, 394],
         "creator": { "name": "Peter", "user_id": "u123" },
+        "create_unix_time_sec": 1668100000,
+        "mod_unix_time_sec": 1668100000,
         "mistROIItem": {
             "species": "",
             "mineralGroupID": "",
@@ -53,6 +56,8 @@ const roi2XItems = `{
         "name": "White spot",
         "locationIndexes": [14, 5, 94],
         "creator": { "name": "Tom", "user_id": "u124" },
+        "create_unix_time_sec": 1668100001,
+        "mod_unix_time_sec": 1668100001,
         "mistROIItem": {
             "species": "",
             "mineralGroupID": "",
@@ -148,7 +153,9 @@ func Test_roiHandler_List(t *testing.T) {
 							"ID_Depth": 0,
 							"ClassificationTrail": "",
 							"formula": ""
-						}
+						},
+						"create_unix_time_sec": 1668100000,
+						"mod_unix_time_sec": 1668100000
 					}
 				}`))),
 			},
@@ -160,6 +167,8 @@ func Test_roiHandler_List(t *testing.T) {
 						"locationIndexes": [99],
 						"shared": false,
 						"creator": { "name": "Tom", "user_id": "u85", "email": ""},
+						"create_unix_time_sec": 1668100003,
+						"mod_unix_time_sec": 1668100003,
 						"mistROIItem": {
 							"species": "",
 							"mineralGroupID": "",
@@ -213,7 +222,9 @@ func Test_roiHandler_List(t *testing.T) {
             "name": "Peter",
             "user_id": "u77",
             "email": ""
-        }
+        },
+        "create_unix_time_sec": 1668100000,
+        "mod_unix_time_sec": 1668100000
     },
     "shared-007": {
         "name": "james bond",
@@ -233,7 +244,9 @@ func Test_roiHandler_List(t *testing.T) {
             "name": "Tom Barber",
             "user_id": "u85",
             "email": "tom@spicule.co.uk"
-        }
+        },
+        "create_unix_time_sec": 1668100003,
+        "mod_unix_time_sec": 1668100003
     }
 }
 `)
@@ -290,7 +303,9 @@ func Example_roiHandler_Post() {
             "name": "Niko Bellic",
             "user_id": "600f2a0806b6c70071d3d174",
             "email": "niko@spicule.co.uk"
-        }
+        },
+        "create_unix_time_sec": 1668100007,
+        "mod_unix_time_sec": 1668100007
     }
 }`))),
 		},
@@ -322,7 +337,9 @@ func Example_roiHandler_Post() {
             "name": "Niko Bellic",
             "user_id": "600f2a0806b6c70071d3d174",
             "email": "niko@spicule.co.uk"
-        }
+        },
+        "create_unix_time_sec": 1668142579,
+        "mod_unix_time_sec": 1668142579
     }
 }`)),
 		},
@@ -348,7 +365,9 @@ func Example_roiHandler_Post() {
             "name": "Niko Bellic",
             "user_id": "600f2a0806b6c70071d3d174",
             "email": "niko@spicule.co.uk"
-        }
+        },
+        "create_unix_time_sec": 1668142580,
+        "mod_unix_time_sec": 1668142580
     }
 }`)),
 		},
@@ -374,7 +393,9 @@ func Example_roiHandler_Post() {
             "name": "Peter",
             "user_id": "u123",
             "email": ""
-        }
+        },
+        "create_unix_time_sec": 1668100000,
+        "mod_unix_time_sec": 1668100000
     },
     "772": {
         "name": "White spot",
@@ -396,7 +417,9 @@ func Example_roiHandler_Post() {
             "name": "Tom",
             "user_id": "u124",
             "email": ""
-        }
+        },
+        "create_unix_time_sec": 1668100001,
+        "mod_unix_time_sec": 1668100001
     },
     "id5": {
         "name": "White spot",
@@ -418,7 +441,9 @@ func Example_roiHandler_Post() {
             "name": "Niko Bellic",
             "user_id": "600f2a0806b6c70071d3d174",
             "email": "niko@spicule.co.uk"
-        }
+        },
+        "create_unix_time_sec": 1668142581,
+        "mod_unix_time_sec": 1668142581
     }
 }`)),
 		},
@@ -445,7 +470,9 @@ func Example_roiHandler_Post() {
             "name": "Niko Bellic",
             "user_id": "600f2a0806b6c70071d3d174",
             "email": "niko@spicule.co.uk"
-        }
+        },
+        "create_unix_time_sec": 1668142583,
+        "mod_unix_time_sec": 1668142583
     }
 }`)),
 		},
@@ -460,6 +487,9 @@ func Example_roiHandler_Post() {
 	var idGen MockIDGenerator
 	idGen.ids = []string{"id3", "id4", "id5", "id6"}
 	svcs := MakeMockSvcs(&mockS3, &idGen, nil, nil)
+	svcs.TimeStamper = &timestamper.MockTimeNowStamper{
+		QueuedTimeStamps: []int64{1668142579, 1668142580, 1668142581, 1668142582, 1668142583},
+	}
 	apiRouter := MakeRouter(svcs)
 
 	const postItem = `{
@@ -590,7 +620,9 @@ func Example_roiHandler_Put() {
             "name": "Niko Bellic",
             "user_id": "600f2a0806b6c70071d3d174",
             "email": "niko@spicule.co.uk"
-        }
+        },
+        "create_unix_time_sec": 1668100000,
+        "mod_unix_time_sec": 1668142579
     },
     "772": {
         "name": "White spot",
@@ -612,7 +644,9 @@ func Example_roiHandler_Put() {
             "name": "Tom",
             "user_id": "u124",
             "email": ""
-        }
+        },
+        "create_unix_time_sec": 1668100001,
+        "mod_unix_time_sec": 1668100001
     }
 }`)),
 		},
@@ -622,6 +656,9 @@ func Example_roiHandler_Put() {
 	}
 
 	svcs := MakeMockSvcs(&mockS3, nil, nil, nil)
+	svcs.TimeStamper = &timestamper.MockTimeNowStamper{
+		QueuedTimeStamps: []int64{1668142579},
+	}
 
 	apiRouter := MakeRouter(svcs)
 
@@ -729,6 +766,8 @@ func Example_roiHandler_Delete() {
             394
         ],
         "creator": { "name": "Peter", "user_id": "600f2a0806b6c70071d3d174" },
+        "create_unix_time_sec": 1668100000,
+        "mod_unix_time_sec": 1668100000,
         "mistROIItem": {
             "species": "",
             "mineralGroupID": "",
@@ -745,6 +784,8 @@ func Example_roiHandler_Delete() {
             94
         ],
         "creator": { "name": "Tom", "user_id": "u124" },
+        "create_unix_time_sec": 1668100001,
+        "mod_unix_time_sec": 1668100001,
         "mistROIItem": {
             "species": "",
             "mineralGroupID": "",
@@ -790,7 +831,9 @@ func Example_roiHandler_Delete() {
             "name": "Tom",
             "user_id": "u124",
             "email": ""
-        }
+        },
+        "create_unix_time_sec": 1668100001,
+        "mod_unix_time_sec": 1668100001
     }
 }`)),
 		},
@@ -870,7 +913,9 @@ func Example_roiHandler_Share() {
         "creator": {
             "name": "The user who shared",
             "user_id": "600f2a0806b6c70071d3d174"
-        }
+        },
+        "create_unix_time_sec": 1668100008,
+        "mod_unix_time_sec": 1668100008
     }
 }`
 
@@ -954,7 +999,9 @@ func Example_roiHandler_Share() {
             "name": "Peter",
             "user_id": "u123",
             "email": ""
-        }
+        },
+        "create_unix_time_sec": 1668100000,
+        "mod_unix_time_sec": 1668142579
     },
     "99": {
         "name": "Shared already",
@@ -974,7 +1021,9 @@ func Example_roiHandler_Share() {
             "name": "The user who shared",
             "user_id": "600f2a0806b6c70071d3d174",
             "email": ""
-        }
+        },
+        "create_unix_time_sec": 1668100008,
+        "mod_unix_time_sec": 1668100008
     }
 }`)),
 		},
@@ -986,6 +1035,9 @@ func Example_roiHandler_Share() {
 	var idGen MockIDGenerator
 	idGen.ids = []string{"16"}
 	svcs := MakeMockSvcs(&mockS3, &idGen, nil, nil)
+	svcs.TimeStamper = &timestamper.MockTimeNowStamper{
+		QueuedTimeStamps: []int64{1668142579},
+	}
 	apiRouter := MakeRouter(svcs)
 
 	const putItem = ""

--- a/api/endpoints/SpectrumAnnotation.go
+++ b/api/endpoints/SpectrumAnnotation.go
@@ -216,7 +216,18 @@ func annotationPost(params handlers.ApiHandlerParams) (interface{}, error) {
 	}
 
 	// Save it & upload
-	saveItem := spectrumAnnotationLine{req.Name, req.RoiID, req.EV, &pixlUser.APIObjectItem{Shared: false, Creator: params.UserInfo}}
+	timeNow := params.Svcs.TimeStamper.GetTimeNowSec()
+	saveItem := spectrumAnnotationLine{
+		req.Name,
+		req.RoiID,
+		req.EV,
+		&pixlUser.APIObjectItem{
+			Shared:              false,
+			Creator:             params.UserInfo,
+			CreatedUnixTimeSec:  timeNow,
+			ModifiedUnixTimeSec: timeNow,
+		},
+	}
 	(*annotationFile)[itemID] = saveItem
 	return *annotationFile, params.Svcs.FS.WriteJSON(params.Svcs.Config.UsersBucket, s3Path, *annotationFile)
 }
@@ -242,7 +253,18 @@ func annotationPut(params handlers.ApiHandlerParams) (interface{}, error) {
 	}
 
 	// Save it & upload
-	saveItem := spectrumAnnotationLine{req.Name, req.RoiID, req.EV, &pixlUser.APIObjectItem{Shared: false, Creator: existing.Creator}}
+	timeNow := params.Svcs.TimeStamper.GetTimeNowSec()
+	saveItem := spectrumAnnotationLine{
+		req.Name,
+		req.RoiID,
+		req.EV,
+		&pixlUser.APIObjectItem{
+			Shared:              false,
+			Creator:             existing.Creator,
+			CreatedUnixTimeSec:  existing.CreatedUnixTimeSec,
+			ModifiedUnixTimeSec: timeNow,
+		},
+	}
 	(*annotationFile)[itemID] = saveItem
 
 	return *annotationFile, params.Svcs.FS.WriteJSON(params.Svcs.Config.UsersBucket, s3Path, *annotationFile)

--- a/api/endpoints/SpectrumAnnotation_test.go
+++ b/api/endpoints/SpectrumAnnotation_test.go
@@ -28,6 +28,7 @@ import (
 	"github.com/aws/aws-sdk-go/service/s3"
 	"github.com/pixlise/core/v2/core/awsutil"
 	"github.com/pixlise/core/v2/core/pixlUser"
+	"github.com/pixlise/core/v2/core/timestamper"
 	"go.mongodb.org/mongo-driver/bson"
 	"go.mongodb.org/mongo-driver/bson/primitive"
 	"go.mongodb.org/mongo-driver/mongo/integration/mtest"
@@ -41,14 +42,18 @@ const annotations2x = `{
 		"roiID": "roi123",
 		"name": "Weird part of spectrum",
 		"shared": false,
-		"creator": { "name": "Tom", "user_id": "u124", "email":"niko@spicule.co.uk" }
+		"creator": { "name": "Tom", "user_id": "u124", "email":"niko@spicule.co.uk" },
+        "create_unix_time_sec": 1668100000,
+        "mod_unix_time_sec": 1668100000
 	},
 	"8": {
 		"eV": 555,
 		"roiID": "roi123",
 		"name": "Left of spectrum",
 		"shared": false,
-		"creator": { "name": "Peter", "user_id": "u123", "email":"niko@spicule.co.uk" }
+		"creator": { "name": "Peter", "user_id": "u123", "email":"niko@spicule.co.uk" },
+        "create_unix_time_sec": 1668100001,
+        "mod_unix_time_sec": 1668100001
 	}
 }`
 
@@ -133,7 +138,9 @@ func Test_spectrumAnnotationHandler_List(t *testing.T) {
 			"name": "right of spectrum",
 			"roiID": "roi111",
 			"shared": true,
-			"creator": { "name": "Tom", "user_id": "u124", "email": "" }
+			"creator": { "name": "Tom", "user_id": "u124", "email": "" },
+			"create_unix_time_sec": 1668100002,
+			"mod_unix_time_sec": 1668100003
 		}
 	}`))),
 			},
@@ -168,7 +175,9 @@ func Test_spectrumAnnotationHandler_List(t *testing.T) {
             "name": "Tom Barber",
             "user_id": "u124",
             "email": "tom@spicule.co.uk"
-        }
+        },
+        "create_unix_time_sec": 1668100000,
+        "mod_unix_time_sec": 1668100000
     },
     "8": {
         "name": "Left of spectrum",
@@ -179,7 +188,9 @@ func Test_spectrumAnnotationHandler_List(t *testing.T) {
             "name": "Peter",
             "user_id": "u123",
             "email": "niko@spicule.co.uk"
-        }
+        },
+        "create_unix_time_sec": 1668100001,
+        "mod_unix_time_sec": 1668100001
     },
     "shared-93": {
         "name": "right of spectrum",
@@ -190,7 +201,9 @@ func Test_spectrumAnnotationHandler_List(t *testing.T) {
             "name": "Tom Barber",
             "user_id": "u124",
             "email": "tom@spicule.co.uk"
-        }
+        },
+        "create_unix_time_sec": 1668100002,
+        "mod_unix_time_sec": 1668100003
     }
 }
 `)
@@ -298,7 +311,9 @@ func Test_spectrumAnnotationHandler_Get(t *testing.T) {
         "name": "Tom Barber",
         "user_id": "u123",
         "email": "tom@spicule.co.uk"
-    }
+    },
+    "create_unix_time_sec": 1668100001,
+    "mod_unix_time_sec": 1668100001
 }
 `)
 
@@ -315,7 +330,9 @@ func Test_spectrumAnnotationHandler_Get(t *testing.T) {
         "name": "Tom Barber",
         "user_id": "u123",
         "email": "tom@spicule.co.uk"
-    }
+    },
+    "create_unix_time_sec": 1668100001,
+    "mod_unix_time_sec": 1668100001
 }
 `)
 	})
@@ -345,7 +362,7 @@ func Example_spectrumAnnotationHandler_Post() {
 		},
 	}
 	mockS3.ExpPutObjectInput = []s3.PutObjectInput{
-		s3.PutObjectInput{
+		{
 			Bucket: aws.String(UsersBucketForUnitTest), Key: aws.String(annotationS3Path), Body: bytes.NewReader([]byte(`{
     "id1": {
         "name": "The modified flag",
@@ -356,11 +373,13 @@ func Example_spectrumAnnotationHandler_Post() {
             "name": "Niko Bellic",
             "user_id": "600f2a0806b6c70071d3d174",
             "email": "niko@spicule.co.uk"
-        }
+        },
+        "create_unix_time_sec": 1668142579,
+        "mod_unix_time_sec": 1668142579
     }
 }`)),
 		},
-		s3.PutObjectInput{
+		{
 			Bucket: aws.String(UsersBucketForUnitTest), Key: aws.String(annotationS3Path), Body: bytes.NewReader([]byte(`{
     "id2": {
         "name": "The modified flag",
@@ -371,11 +390,13 @@ func Example_spectrumAnnotationHandler_Post() {
             "name": "Niko Bellic",
             "user_id": "600f2a0806b6c70071d3d174",
             "email": "niko@spicule.co.uk"
-        }
+        },
+        "create_unix_time_sec": 1668142580,
+        "mod_unix_time_sec": 1668142580
     }
 }`)),
 		},
-		s3.PutObjectInput{
+		{
 			Bucket: aws.String(UsersBucketForUnitTest), Key: aws.String(annotationS3Path), Body: bytes.NewReader([]byte(`{
     "5": {
         "name": "Weird part of spectrum",
@@ -386,7 +407,9 @@ func Example_spectrumAnnotationHandler_Post() {
             "name": "Tom",
             "user_id": "u124",
             "email": "niko@spicule.co.uk"
-        }
+        },
+        "create_unix_time_sec": 1668100000,
+        "mod_unix_time_sec": 1668100000
     },
     "8": {
         "name": "Left of spectrum",
@@ -397,7 +420,9 @@ func Example_spectrumAnnotationHandler_Post() {
             "name": "Peter",
             "user_id": "u123",
             "email": "niko@spicule.co.uk"
-        }
+        },
+        "create_unix_time_sec": 1668100001,
+        "mod_unix_time_sec": 1668100001
     },
     "id3": {
         "name": "The modified flag",
@@ -408,20 +433,25 @@ func Example_spectrumAnnotationHandler_Post() {
             "name": "Niko Bellic",
             "user_id": "600f2a0806b6c70071d3d174",
             "email": "niko@spicule.co.uk"
-        }
+        },
+        "create_unix_time_sec": 1668142581,
+        "mod_unix_time_sec": 1668142581
     }
 }`)),
 		},
 	}
 	mockS3.QueuedPutObjectOutput = []*s3.PutObjectOutput{
-		&s3.PutObjectOutput{},
-		&s3.PutObjectOutput{},
-		&s3.PutObjectOutput{},
+		{},
+		{},
+		{},
 	}
 
 	var idGen MockIDGenerator
 	idGen.ids = []string{"id1", "id2", "id3"}
 	svcs := MakeMockSvcs(&mockS3, &idGen, nil, nil)
+	svcs.TimeStamper = &timestamper.MockTimeNowStamper{
+		QueuedTimeStamps: []int64{1668142579, 1668142580, 1668142581},
+	}
 	apiRouter := MakeRouter(svcs)
 
 	body := `{
@@ -460,7 +490,9 @@ func Example_spectrumAnnotationHandler_Post() {
 	//             "name": "Niko Bellic",
 	//             "user_id": "600f2a0806b6c70071d3d174",
 	//             "email": "niko@spicule.co.uk"
-	//         }
+	//         },
+	//         "create_unix_time_sec": 1668142579,
+	//         "mod_unix_time_sec": 1668142579
 	//     }
 	// }
 	//
@@ -475,7 +507,9 @@ func Example_spectrumAnnotationHandler_Post() {
 	//             "name": "Niko Bellic",
 	//             "user_id": "600f2a0806b6c70071d3d174",
 	//             "email": "niko@spicule.co.uk"
-	//         }
+	//         },
+	//         "create_unix_time_sec": 1668142580,
+	//         "mod_unix_time_sec": 1668142580
 	//     }
 	// }
 	//
@@ -490,7 +524,9 @@ func Example_spectrumAnnotationHandler_Post() {
 	//             "name": "Tom",
 	//             "user_id": "u124",
 	//             "email": "niko@spicule.co.uk"
-	//         }
+	//         },
+	//         "create_unix_time_sec": 1668100000,
+	//         "mod_unix_time_sec": 1668100000
 	//     },
 	//     "8": {
 	//         "name": "Left of spectrum",
@@ -501,7 +537,9 @@ func Example_spectrumAnnotationHandler_Post() {
 	//             "name": "Peter",
 	//             "user_id": "u123",
 	//             "email": "niko@spicule.co.uk"
-	//         }
+	//         },
+	//         "create_unix_time_sec": 1668100001,
+	//         "mod_unix_time_sec": 1668100001
 	//     },
 	//     "id3": {
 	//         "name": "The modified flag",
@@ -512,7 +550,9 @@ func Example_spectrumAnnotationHandler_Post() {
 	//             "name": "Niko Bellic",
 	//             "user_id": "600f2a0806b6c70071d3d174",
 	//             "email": "niko@spicule.co.uk"
-	//         }
+	//         },
+	//         "create_unix_time_sec": 1668142581,
+	//         "mod_unix_time_sec": 1668142581
 	//     }
 	// }
 }
@@ -549,7 +589,7 @@ func Example_spectrumAnnotationHandler_Put() {
 	}
 	// NOTE: PUT expected JSON needs to have spaces not tabs
 	mockS3.ExpPutObjectInput = []s3.PutObjectInput{
-		s3.PutObjectInput{
+		{
 			Bucket: aws.String(UsersBucketForUnitTest), Key: aws.String(annotationS3Path), Body: bytes.NewReader([]byte(`{
     "5": {
         "name": "Updated Item",
@@ -560,7 +600,9 @@ func Example_spectrumAnnotationHandler_Put() {
             "name": "Tom",
             "user_id": "u124",
             "email": "niko@spicule.co.uk"
-        }
+        },
+        "create_unix_time_sec": 1668100000,
+        "mod_unix_time_sec": 1668142579
     },
     "8": {
         "name": "Left of spectrum",
@@ -571,16 +613,21 @@ func Example_spectrumAnnotationHandler_Put() {
             "name": "Peter",
             "user_id": "u123",
             "email": "niko@spicule.co.uk"
-        }
+        },
+        "create_unix_time_sec": 1668100001,
+        "mod_unix_time_sec": 1668100001
     }
 }`)),
 		},
 	}
 	mockS3.QueuedPutObjectOutput = []*s3.PutObjectOutput{
-		&s3.PutObjectOutput{},
+		{},
 	}
 
 	svcs := MakeMockSvcs(&mockS3, nil, nil, nil)
+	svcs.TimeStamper = &timestamper.MockTimeNowStamper{
+		QueuedTimeStamps: []int64{1668142579},
+	}
 	apiRouter := MakeRouter(svcs)
 
 	const putItem = `{
@@ -640,7 +687,9 @@ func Example_spectrumAnnotationHandler_Put() {
 	//             "name": "Tom",
 	//             "user_id": "u124",
 	//             "email": "niko@spicule.co.uk"
-	//         }
+	//         },
+	//         "create_unix_time_sec": 1668100000,
+	//         "mod_unix_time_sec": 1668142579
 	//     },
 	//     "8": {
 	//         "name": "Left of spectrum",
@@ -651,7 +700,9 @@ func Example_spectrumAnnotationHandler_Put() {
 	//             "name": "Peter",
 	//             "user_id": "u123",
 	//             "email": "niko@spicule.co.uk"
-	//         }
+	//         },
+	//         "create_unix_time_sec": 1668100001,
+	//         "mod_unix_time_sec": 1668100001
 	//     }
 	// }
 }
@@ -712,7 +763,7 @@ func Example_spectrumAnnotationHandler_Delete() {
 	}
 
 	mockS3.ExpPutObjectInput = []s3.PutObjectInput{
-		s3.PutObjectInput{
+		{
 			Bucket: aws.String(UsersBucketForUnitTest), Key: aws.String(annotationS3Path), Body: bytes.NewReader([]byte(`{
     "8": {
         "name": "Left of spectrum",
@@ -723,17 +774,19 @@ func Example_spectrumAnnotationHandler_Delete() {
             "name": "Peter",
             "user_id": "u123",
             "email": "niko@spicule.co.uk"
-        }
+        },
+        "create_unix_time_sec": 1668100001,
+        "mod_unix_time_sec": 1668100001
     }
 }`)),
 		},
-		s3.PutObjectInput{
+		{
 			Bucket: aws.String(UsersBucketForUnitTest), Key: aws.String(annotationSharedS3Path), Body: bytes.NewReader([]byte(`{}`)),
 		},
 	}
 	mockS3.QueuedPutObjectOutput = []*s3.PutObjectOutput{
-		&s3.PutObjectOutput{},
-		&s3.PutObjectOutput{},
+		{},
+		{},
 	}
 
 	svcs := MakeMockSvcs(&mockS3, nil, nil, nil)
@@ -834,6 +887,9 @@ func Example_spectrumAnnotationHandler_Share() {
 			Body: ioutil.NopCloser(bytes.NewReader([]byte(annotations2x))),
 		},
 		// Shared file
+		// NOTE that no create_unix_time_sec or mod_unix_time_sec supplied
+		// this is because we didn't have this field in the past, pretend this is an
+		// old shared file, and see if the put at the end omits the empty 2 fields
 		{
 			Body: ioutil.NopCloser(bytes.NewReader([]byte(`{
     "25": {
@@ -852,7 +908,7 @@ func Example_spectrumAnnotationHandler_Share() {
 	}
 	// NOTE: PUT expected JSON needs to have spaces not tabs
 	mockS3.ExpPutObjectInput = []s3.PutObjectInput{
-		s3.PutObjectInput{
+		{
 			Bucket: aws.String(UsersBucketForUnitTest), Key: aws.String(annotationSharedS3Path), Body: bytes.NewReader([]byte(`{
     "25": {
         "name": "Weird part of spectrum",
@@ -874,13 +930,15 @@ func Example_spectrumAnnotationHandler_Share() {
             "name": "Peter",
             "user_id": "u123",
             "email": "niko@spicule.co.uk"
-        }
+        },
+        "create_unix_time_sec": 1668100001,
+        "mod_unix_time_sec": 1668100001
     }
 }`)),
 		},
 	}
 	mockS3.QueuedPutObjectOutput = []*s3.PutObjectOutput{
-		&s3.PutObjectOutput{},
+		{},
 	}
 
 	var idGen MockIDGenerator

--- a/api/endpoints/ViewStateCollection.go
+++ b/api/endpoints/ViewStateCollection.go
@@ -209,9 +209,12 @@ func viewStateCollectionPut(params handlers.ApiHandlerParams) (interface{}, erro
 	}
 
 	// Include creator info
+	timeNow := params.Svcs.TimeStamper.GetTimeNowSec()
 	collectionToSave.APIObjectItem = &pixlUser.APIObjectItem{
-		Shared:  false,
-		Creator: params.UserInfo,
+		Shared:              false,
+		Creator:             params.UserInfo,
+		CreatedUnixTimeSec:  timeNow,
+		ModifiedUnixTimeSec: timeNow,
 	}
 
 	// Save it
@@ -276,9 +279,12 @@ func viewStateCollectionShare(params handlers.ApiHandlerParams) (interface{}, er
 
 	// Set shared flag
 	if collectionContents.APIObjectItem == nil {
+		timeNow := params.Svcs.TimeStamper.GetTimeNowSec()
 		collectionContents.APIObjectItem = &pixlUser.APIObjectItem{
-			Shared:  true,
-			Creator: params.UserInfo,
+			Shared:              true,
+			Creator:             params.UserInfo,
+			CreatedUnixTimeSec:  timeNow,
+			ModifiedUnixTimeSec: timeNow,
 		}
 	} else {
 		collectionContents.Shared = true

--- a/api/endpoints/ViewStateCollection_test.go
+++ b/api/endpoints/ViewStateCollection_test.go
@@ -29,6 +29,7 @@ import (
 	"github.com/aws/aws-sdk-go/service/s3"
 	"github.com/pixlise/core/v2/core/awsutil"
 	"github.com/pixlise/core/v2/core/pixlUser"
+	"github.com/pixlise/core/v2/core/timestamper"
 	"go.mongodb.org/mongo-driver/mongo/integration/mtest"
 )
 
@@ -693,7 +694,9 @@ func Example_viewStateHandler_PutCollection() {
         "name": "Niko Bellic",
         "user_id": "600f2a0806b6c70071d3d174",
         "email": "niko@spicule.co.uk"
-    }
+    },
+    "create_unix_time_sec": 1668142579,
+    "mod_unix_time_sec": 1668142579
 }`)),
 		},
 	}
@@ -703,6 +706,9 @@ func Example_viewStateHandler_PutCollection() {
 	}
 
 	svcs := MakeMockSvcs(&mockS3, nil, nil, nil)
+	svcs.TimeStamper = &timestamper.MockTimeNowStamper{
+		QueuedTimeStamps: []int64{1668142579},
+	}
 	apiRouter := MakeRouter(svcs)
 
 	req, _ := http.NewRequest("PUT", "/view-state/collections/TheDataSetID/The best collection 23_09_2021", bytes.NewReader([]byte(`{
@@ -1019,7 +1025,9 @@ func Example_viewStateHandler_ShareCollection() {
         "name": "Niko Bellic",
         "user_id": "600f2a0806b6c70071d3d174",
         "email": "niko@spicule.co.uk"
-    }
+    },
+    "create_unix_time_sec": 1668142579,
+    "mod_unix_time_sec": 1668142579
 }`)),
 		},
 	}
@@ -1028,6 +1036,9 @@ func Example_viewStateHandler_ShareCollection() {
 	}
 
 	svcs := MakeMockSvcs(&mockS3, nil, nil, nil)
+	svcs.TimeStamper = &timestamper.MockTimeNowStamper{
+		QueuedTimeStamps: []int64{1668142579},
+	}
 	apiRouter := MakeRouter(svcs)
 
 	// User file not there, should say not found

--- a/api/endpoints/ViewStateWorkspace_test.go
+++ b/api/endpoints/ViewStateWorkspace_test.go
@@ -29,6 +29,7 @@ import (
 	"github.com/aws/aws-sdk-go/service/s3"
 	"github.com/pixlise/core/v2/core/awsutil"
 	"github.com/pixlise/core/v2/core/pixlUser"
+	"github.com/pixlise/core/v2/core/timestamper"
 	"go.mongodb.org/mongo-driver/bson"
 	"go.mongodb.org/mongo-driver/bson/primitive"
 	"go.mongodb.org/mongo-driver/mongo/integration/mtest"
@@ -946,7 +947,9 @@ func Example_viewStateHandler_PutSaved_Force() {
         "name": "Niko Bellic",
         "user_id": "600f2a0806b6c70071d3d174",
         "email": "niko@spicule.co.uk"
-    }
+    },
+    "create_unix_time_sec": 1668142579,
+    "mod_unix_time_sec": 1668142579
 }`)),
 		},
 	}
@@ -956,6 +959,9 @@ func Example_viewStateHandler_PutSaved_Force() {
 	}
 
 	svcs := MakeMockSvcs(&mockS3, nil, nil, nil)
+	svcs.TimeStamper = &timestamper.MockTimeNowStamper{
+		QueuedTimeStamps: []int64{1668142579},
+	}
 	apiRouter := MakeRouter(svcs)
 
 	req, _ := http.NewRequest("PUT", "/view-state/saved/TheDataSetID/viewstate123?force=true", bytes.NewReader([]byte(`{
@@ -1069,6 +1075,9 @@ func Example_viewStateHandler_PutSaved_OverwriteAlreadyExists() {
 	}
 
 	svcs := MakeMockSvcs(&mockS3, nil, nil, nil)
+	svcs.TimeStamper = &timestamper.MockTimeNowStamper{
+		QueuedTimeStamps: []int64{1668142579},
+	}
 	apiRouter := MakeRouter(svcs)
 
 	req, _ := http.NewRequest("PUT", "/view-state/saved/TheDataSetID/viewstate123", bytes.NewReader([]byte(`{
@@ -1785,7 +1794,9 @@ func Example_viewStateHandler_ShareViewState() {
         "name": "Niko Bellic",
         "user_id": "600f2a0806b6c70071d3d174",
         "email": "niko@spicule.co.uk"
-    }
+    },
+    "create_unix_time_sec": 1668142579,
+    "mod_unix_time_sec": 1668142579
 }`)),
 		},
 	}
@@ -1794,6 +1805,9 @@ func Example_viewStateHandler_ShareViewState() {
 	}
 
 	svcs := MakeMockSvcs(&mockS3, nil, nil, nil)
+	svcs.TimeStamper = &timestamper.MockTimeNowStamper{
+		QueuedTimeStamps: []int64{1668142579},
+	}
 	apiRouter := MakeRouter(svcs)
 
 	// User file not there, should say not found
@@ -1893,7 +1907,10 @@ func Example_viewStateHandler_ShareViewState_AutoShare() {
 					"ternaryPlots": { "66": { "expressionIDs": ["shared-expr2"], "visibleROIs": ["roi2"] } }
 				 },
 				 "name": "222",
-				"description": "the description of 222"
+				"description": "the description of 222",
+				"creator": { "name": "Kyle", "user_id": "u124" },
+				"create_unix_time_sec": 1668100010,
+				"mod_unix_time_sec": 1668100011
 			}`))),
 		},
 
@@ -1904,7 +1921,9 @@ func Example_viewStateHandler_ShareViewState_AutoShare() {
 		"name": "Dark patch 2",
 		"description": "The second dark patch",
 		"locationIndexes": [4, 55, 394],
-		"creator": { "name": "Peter", "user_id": "u123" }
+		"creator": { "name": "Peter", "user_id": "u123" },
+        "create_unix_time_sec": 1668100012,
+        "mod_unix_time_sec": 1668100013
 	}
 }`))),
 		},
@@ -1915,7 +1934,9 @@ func Example_viewStateHandler_ShareViewState_AutoShare() {
 		"shared": true,
 		"description": "The shared patch",
 		"locationIndexes": [4, 55, 394],
-		"creator": { "name": "PeterN", "user_id": "u123" }
+		"creator": { "name": "PeterN", "user_id": "u123" },
+        "create_unix_time_sec": 1668100014,
+        "mod_unix_time_sec": 1668100015
 	}
 }`))),
 		},
@@ -1931,7 +1952,9 @@ func Example_viewStateHandler_ShareViewState_AutoShare() {
 			"user_id": "444",
 			"name": "Niko",
 			"email": "niko@spicule.co.uk"
-		}
+		},
+        "create_unix_time_sec": 1668100016,
+        "mod_unix_time_sec": 1668100017
 	},
 	"expr1": {
 		"name": "Calcium weight%",
@@ -1942,7 +1965,9 @@ func Example_viewStateHandler_ShareViewState_AutoShare() {
 			"user_id": "999",
 			"name": "Peter N",
 			"email": "peter@spicule.co.uk"
-		}
+		},
+        "create_unix_time_sec": 1668100018,
+        "mod_unix_time_sec": 1668100019
 	}
 }`))),
 		},
@@ -1971,7 +1996,9 @@ func Example_viewStateHandler_ShareViewState_AutoShare() {
 			"user_id": "999",
 			"name": "Peter N",
 			"email": "niko@spicule.co.uk"
-		}
+		},
+        "create_unix_time_sec": 1668100020,
+        "mod_unix_time_sec": 1668100021
 	}
 }`))),
 		},
@@ -2000,7 +2027,9 @@ func Example_viewStateHandler_ShareViewState_AutoShare() {
 			"user_id": "999",
 			"name": "Peter N",
 			"email": "niko@spicule.co.uk"
-		}
+		},
+        "create_unix_time_sec": 1668100022,
+        "mod_unix_time_sec": 1668100023
 	}
 }`))),
 		},
@@ -2030,7 +2059,9 @@ func Example_viewStateHandler_ShareViewState_AutoShare() {
             "name": "PeterN",
             "user_id": "u123",
             "email": ""
-        }
+        },
+        "create_unix_time_sec": 1668100014,
+        "mod_unix_time_sec": 1668100015
     },
     "roi2(sh)": {
         "name": "Dark patch 2",
@@ -2052,7 +2083,9 @@ func Example_viewStateHandler_ShareViewState_AutoShare() {
             "name": "Peter",
             "user_id": "u123",
             "email": ""
-        }
+        },
+        "create_unix_time_sec": 1668100012,
+        "mod_unix_time_sec": 1668142579
     }
 }`)),
 		},
@@ -2068,7 +2101,9 @@ func Example_viewStateHandler_ShareViewState_AutoShare() {
             "name": "Peter N",
             "user_id": "999",
             "email": "peter@spicule.co.uk"
-        }
+        },
+        "create_unix_time_sec": 1668100018,
+        "mod_unix_time_sec": 16681425780
     }
 }`)),
 		},
@@ -2096,7 +2131,9 @@ func Example_viewStateHandler_ShareViewState_AutoShare() {
             "name": "Peter N",
             "user_id": "999",
             "email": "niko@spicule.co.uk"
-        }
+        },
+        "create_unix_time_sec": 1668100022,
+        "mod_unix_time_sec": 1668100023
     },
     "rgbmix-123roi": {
         "name": "Ca-Ti-Al ratios",
@@ -2120,7 +2157,9 @@ func Example_viewStateHandler_ShareViewState_AutoShare() {
             "name": "Peter N",
             "user_id": "999",
             "email": "niko@spicule.co.uk"
-        }
+        },
+        "create_unix_time_sec": 1668100020,
+        "mod_unix_time_sec": 1668142581
     }
 }`)),
 		},
@@ -2229,10 +2268,12 @@ func Example_viewStateHandler_ShareViewState_AutoShare() {
     "description": "the description of 222",
     "shared": true,
     "creator": {
-        "name": "Niko Bellic",
-        "user_id": "600f2a0806b6c70071d3d174",
-        "email": "niko@spicule.co.uk"
-    }
+        "name": "Kyle",
+        "user_id": "u124",
+        "email": ""
+    },
+    "create_unix_time_sec": 1668100010,
+    "mod_unix_time_sec": 1668142582
 }`)),
 		},
 	}
@@ -2246,6 +2287,9 @@ func Example_viewStateHandler_ShareViewState_AutoShare() {
 	var idGen MockIDGenerator
 	idGen.ids = []string{"roi2(sh)", "expr1(sh)", "123roi"}
 	svcs := MakeMockSvcs(&mockS3, &idGen, nil, nil)
+	svcs.TimeStamper = &timestamper.MockTimeNowStamper{
+		QueuedTimeStamps: []int64{1668142579, 16681425780, 1668142581, 1668142582},
+	}
 	apiRouter := MakeRouter(svcs)
 
 	// User file not there, should say not found

--- a/core/pixlUser/sharedDataCreator.go
+++ b/core/pixlUser/sharedDataCreator.go
@@ -28,8 +28,10 @@ type UserInfo struct {
 // APIObjectItem API endpoints send around versions of this struct (with extra fields depending on the data type)
 // TODO: maybe need to move this to its own API structures place? It's currently used in more places than just API handlers though.
 type APIObjectItem struct {
-	Shared  bool     `json:"shared"`
-	Creator UserInfo `json:"creator"`
+	Shared              bool     `json:"shared"`
+	Creator             UserInfo `json:"creator"`
+	CreatedUnixTimeSec  int64    `json:"create_unix_time_sec,omitempty"`
+	ModifiedUnixTimeSec int64    `json:"mod_unix_time_sec,omitempty"`
 }
 
 // A special shared user ID so code knows if it's referring to this...

--- a/core/quantModel/job-summary.go
+++ b/core/quantModel/job-summary.go
@@ -28,6 +28,7 @@ type JobSummaryItem struct {
 	Params   JobStartingParametersWithPMCCount `json:"params"`
 	Elements []string                          `json:"elements"`
 	*JobStatus
+	// TODO: Make this also contain *APIObjectItem and remove its own Shared field...
 }
 
 // SetMissingSummaryFields - ensure the fields all exist over time.

--- a/core/roiModel/roi.go
+++ b/core/roiModel/roi.go
@@ -189,8 +189,10 @@ func GetROIs(svcs *services.APIServices, userID string, datasetID string, outMap
 		toSave := ROISavedItem{
 			ROIItem: item.ROIItem,
 			APIObjectItem: &pixlUser.APIObjectItem{
-				Shared:  sharedFile,
-				Creator: item.Creator,
+				Shared:              sharedFile,
+				Creator:             item.Creator,
+				CreatedUnixTimeSec:  item.CreatedUnixTimeSec,
+				ModifiedUnixTimeSec: item.ModifiedUnixTimeSec,
 			},
 		}
 
@@ -252,8 +254,10 @@ func ShareROIs(svcs *services.APIServices, userID string, datasetID string, roiI
 				MistROIItem:     roiItem.MistROIItem,
 			},
 			APIObjectItem: &pixlUser.APIObjectItem{
-				Shared:  true,
-				Creator: roiItem.Creator,
+				Shared:              true,
+				Creator:             roiItem.Creator,
+				CreatedUnixTimeSec:  roiItem.CreatedUnixTimeSec,
+				ModifiedUnixTimeSec: svcs.TimeStamper.GetTimeNowSec(),
 			},
 		}
 


### PR DESCRIPTION
…r main data files: expressions, element sets, RGB mixes, ROIs, spectrum annotations, collections and workspaces. NOTE that quantifications is missing, this is because they already have a created time in the param structure within the quant summary files. We may want to add the time stamps in future for uniformity but I didn't do it in this round