### PR TITLE
refactor: connection to mongo based on env vars

### DIFF
--- a/internal/lambdas/data-import/main.go
+++ b/internal/lambdas/data-import/main.go
@@ -21,13 +21,14 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"log"
+	"os"
+	"time"
+
 	mongoDBConnection "github.com/pixlise/core/v2/core/mongo"
 	"github.com/pixlise/core/v2/core/timestamper"
 	"go.mongodb.org/mongo-driver/mongo"
 	"go.mongodb.org/mongo-driver/mongo/readpref"
-	"log"
-	"os"
-	"time"
 
 	"github.com/aws/aws-lambda-go/lambda"
 	"github.com/pixlise/core/v2/core/awsutil"
@@ -191,7 +192,8 @@ func connectMongo(ourLogger logger.ILogger) *mongo.Client {
 	var mongoClient *mongo.Client
 	var err error
 	// Connect to mongo
-	if len("pixlise-db.cluster-clcm0b2sosn0.us-east-1.docdb.amazonaws.com:27017") > 0 && len("pixlise") > 0 && len("pixlise/docdb/masteruser") > 0 {
+	mongoSecret := os.Getenv("DB_SECRET_NAME")
+	if len(mongoSecret) > 0 {
 		// Remote is configured, connect to it
 		mongoConnectionInfo, err := mongoDBConnection.GetMongoConnectionInfoFromSecretCache("pixlise/docdb/masteruser")
 		if err != nil {


### PR DESCRIPTION
Will source database connection info from secretsmanager if the DB_SECRET_NAME environment variable is present; otherwise, will fall back to constructing the database URI based on separate env vars.

Essentially, we want to connect using the database info stored in secretsmanager when the application is running in a cloud environment. Otherwise, we will want direct control over the connection (e.g. when running locally etc.).

When running as a deployed API (in our kuberenetes environment), the `config.MongoSecret` variable will be checked (code: [here](https://github.com/pixlise/core/blob/e13ce3836dd61f4761e2a9c5295ce0965b14a592/api/services/apiServices.go#L172))first, when running as a lambda (`data-import` tool), the `DB_SECRET_NAME` will be checked (code [here](https://github.com/pixlise/core/blob/4b1d97e035c1b338f3428fa65a0a40b72180100e/internal/lambdas/data-import/main.go#L195-L196)). Both of these values are set in the orchestrating deployment code (cdk/k8s).

If you are running the application locally, just ensure that the two controlling variables mentioned above are unset. When this is the case, the application will fall back to `ConnectToLocalMongo` which sources database connection info from the following:
- `PIXLISE_CONFIG_DB_HOST`
- `PIXLISE_CONFIG_DB_USER`
- `PIXLISE_CONFIG_DB_PASS`
- `PIXLISE_CONFIG_DB_PORT`