### PR TITLE
feat: use generics for config-loader and re-use for int test

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,5 @@ core/fileaccess/test-output/
 #binary files
 integrationTest
 .vscode/
+
+*.secret.*

--- a/api/config/config_test.go
+++ b/api/config/config_test.go
@@ -25,8 +25,9 @@ import (
 
 // Check the summary filename gets created correctly
 func Test_InitializeConfigWithFile(t *testing.T) {
+	var cfg APIConfig
 	want := "buildsBucket"
-	cfg, err := NewConfigFromFile("./example_config.json")
+	cfg, err := NewConfigFromFile("./example_config.json", cfg)
 	if err != nil {
 		t.Fatalf("Error initializing config: %v", err)
 	}
@@ -37,9 +38,10 @@ func Test_InitializeConfigWithFile(t *testing.T) {
 
 // Check the quant path is calculated correctly
 func Test_InitializeConfigWithJsonString(t *testing.T) {
+	var cfg APIConfig
 	want := "buildsBucketCustomConfig"
 	configStr := fmt.Sprintf(`{"BuildsBucket": "%s"}`, want)
-	cfg, err := NewConfigFromJsonString(configStr)
+	cfg, err := NewConfigFromJsonString(configStr, cfg)
 	if err != nil {
 		t.Fatalf("Error initializing config: %v", err)
 	}
@@ -50,9 +52,10 @@ func Test_InitializeConfigWithJsonString(t *testing.T) {
 
 // Check that the config can be overridden with Environment Variables
 func Test_OverrideConfigWithEnvVars(t *testing.T) {
+	var cfg APIConfig
 	want := "ENV-SET-BuildsBucket"
 	os.Setenv("PIXLISE_CONFIG_BuildsBucket", want)
-	cfg, err := NewConfigFromFile("./example_config.json")
+	cfg, err := NewConfigFromFile("./example_config.json", cfg)
 	if err != nil {
 		t.Fatalf("Error initializing config: %v", err)
 	}

--- a/internal/cmdline-tools/api-integration-test/config.go
+++ b/internal/cmdline-tools/api-integration-test/config.go
@@ -1,0 +1,35 @@
+package main
+
+import (
+	"flag"
+
+	"github.com/pixlise/core/v3/api/config"
+)
+
+type IntegrationTestConfig struct {
+	Environment       string // environment name is one of [dev, staging, prod] OR a review environment name (eg review-env-blah, so without -api.review at the end)
+	Username          string // Auth0 user
+	Password          string // Auth0 password
+	Auth0UserID       string // Auth0 user id (without Auth0| prefix)
+	Auth0ClientID     string // Auth0 API client id
+	Auth0ClientSecret string // Auth0 API secret
+	Auth0Domain       string // Auth0 API domain eg something.au.auth0.com
+	Auth0Audience     string // Auth0 API audience
+	ExpectedVersion   string // what we expect the API to return, eg 2.0.8-RC12. Or nil to skip check
+}
+
+func LoadConfig() (IntegrationTestConfig, error) {
+	var cfg IntegrationTestConfig
+	var err error
+
+	configFilePath := flag.String("configPath", "", "path to the json file holding a set of custom config for the integration test")
+	flag.Parse()
+
+	if configFilePath != nil && *configFilePath != "" {
+		cfg, err = config.NewConfigFromFile(*configFilePath, cfg)
+	}
+	if err != nil {
+		return cfg, err
+	}
+	return cfg, nil
+}


### PR DESCRIPTION
Want to load the config struct for integration tests in the same way as we do for the API (load from json file and then override based on PIXLISE_CONFIG_* environment variables). To do this, I refactored config loader functions to use generics; had to just use `T any` types :/

Then changed the integration tests to use a single configPath flag instead of a big set of os args; config-loader tests still passed though I've not yet tried building and running the actual integration tests