### PR TITLE
Max Field Bump, Local Mongo Direct Connect

### DIFF
--- a/api/ws/wsHelpers/fields.go
+++ b/api/ws/wsHelpers/fields.go
@@ -6,9 +6,9 @@ import (
 	"github.com/pixlise/core/v4/core/errorwithstatus"
 )
 
-const IdFieldMaxLength = 16
+const IdFieldMaxLength = 32
 const Auth0UserIdFieldMaxLength = 32
-const DescriptionFieldMaxLength = 512
+const DescriptionFieldMaxLength = 1024 * 5
 const SourceCodeMaxLength = 1024 * 1024 * 5 // Trying to be very generous here, but maybe this is not enough?
 const TagListMaxLength = 100
 

--- a/core/mongoDBConnection/local.go
+++ b/core/mongoDBConnection/local.go
@@ -40,7 +40,7 @@ func connectToLocalMongoDB(log logger.ILogger) (*mongo.Client, error) {
 		mongoUri = "mongodb://localhost"
 	}
 	//ctx := context.Background()
-	client, err := mongo.Connect(context.TODO(), options.Client().ApplyURI(mongoUri).SetMonitor(cmdMonitor))
+	client, err := mongo.Connect(context.TODO(), options.Client().ApplyURI(mongoUri).SetMonitor(cmdMonitor).SetDirect(true))
 	if err != nil {
 		return nil, fmt.Errorf("Failed to create new local mongo DB connection: %v", err)
 	}

--- a/internal/cmd-line-tools/api-integration-test/testUserGroups.go
+++ b/internal/cmd-line-tools/api-integration-test/testUserGroups.go
@@ -389,12 +389,12 @@ func testAddRemoveUserAsGroupMember(u2 wstestlib.ScriptedTestUser, nonAdminUserI
 func testUserGroupAdminAdd(u2 wstestlib.ScriptedTestUser, nonAdminUserId string) {
 	// Edits by admin of group
 	u2.AddSendReqAction("Add admin user to bad group id",
-		`{"userGroupAddAdminReq":{"groupId": "way-too-long-group-id", "adminUserId": "u123"}}`,
+		`{"userGroupAddAdminReq":{"groupId": "way-too-long-group-id-way-too-long-group-id-way-too-long-group-id-way-too-long-group-id", "adminUserId": "u123"}}`,
 		`{"msgId":15,"status":"WS_BAD_REQUEST","errorText": "GroupId is too long","userGroupAddAdminResp":{}}`,
 	)
 
 	u2.AddSendReqAction("Add bad admin user id to group id",
-		`{"userGroupAddAdminReq":{"groupId": "non-existant", "adminUserId": "admin-user-id-that-is-way-too-long even-for-auth0"}}`,
+		`{"userGroupAddAdminReq":{"groupId": "non-existant", "adminUserId": "admin-user-id-that-is-way-too-long even-for-auth0-admin-user-id-that-is-way-too-long even-for-auth0"}}`,
 		`{"msgId":16,"status":"WS_BAD_REQUEST","errorText": "AdminUserId is too long","userGroupAddAdminResp":{}}`,
 	)
 


### PR DESCRIPTION
- Id field needs to be longer when we're requesting prefixed ids, ran against description field max with diffraction expression auto-description
- adds direct connect flag to local mongo connection so it doesn't fail on vpn (finally fixed!)