### PR TITLE
ROI Updating and Selection Bugs

### DIFF
--- a/api/ws/handlers/roi.go
+++ b/api/ws/handlers/roi.go
@@ -278,7 +278,7 @@ func updateROI(roi *protos.ROIItem, hctx wsHelpers.HandlerContext) (*protos.ROII
 	// Once created, these can't be set to empty
 	if roi.ScanEntryIndexesEncoded != nil && !utils.SlicesEqual(dbItem.ScanEntryIndexesEncoded, roi.ScanEntryIndexesEncoded) {
 		dbItem.ScanEntryIndexesEncoded = roi.ScanEntryIndexesEncoded
-		update = append(update, bson.E{Key: "ScanEntryIndexesEncoded", Value: roi.ScanEntryIndexesEncoded})
+		update = append(update, bson.E{Key: "scanentryindexesencoded", Value: roi.ScanEntryIndexesEncoded})
 	}
 
 	// Once created, these can't be set to empty
@@ -310,7 +310,7 @@ func updateROI(roi *protos.ROIItem, hctx wsHelpers.HandlerContext) (*protos.ROII
 	}
 
 	if result.MatchedCount != 1 {
-		hctx.Svcs.Log.Errorf("ROI UpdateByID result had unexpected counts %+v id: %v", result, roi.Id)
+		hctx.Svcs.Log.Errorf("ROI UpdateByID result had unexpected counts %v id: %v", result, roi.Id)
 	}
 
 	// Return the merged item we validated, which in theory is in the DB now

--- a/api/ws/handlers/selection-entry.go
+++ b/api/ws/handlers/selection-entry.go
@@ -93,8 +93,9 @@ func writeSelection(id string, idxs *protos.ScanEntryRange, db *mongo.Database, 
 		return err
 	}
 
-	if dbResult.UpsertedCount != 1 && dbResult.ModifiedCount != 1 {
-		logger.Errorf("writeSelection UpdateByID result had unexpected counts %+v", dbResult)
+	// Modified and Upsert counts will be 0 if the selection hasn't changed, so we just check matched
+	if dbResult.MatchedCount != 1 {
+		logger.Errorf("writeSelection (%v) UpdateByID result had unexpected counts %+v", id, dbResult)
 	}
 
 	return nil


### PR DESCRIPTION
Fixes bug with ROI updating where the wrong field (title case) was being updated for scan entries, fixes selection log error when selection hasn't changed