### PR TITLE
Added importer clear-before-save setting that deletes scan/image/beam…

### DIFF
--- a/api/dataimport/internal/converters/pixlem/import.go
+++ b/api/dataimport/internal/converters/pixlem/import.go
@@ -152,6 +152,9 @@ func (p PIXLEM) Import(importPath string, pseudoIntensityRangesPath string, data
 
 		log.Infof("Imported scan with RTT: %v", rtt)
 		data.DatasetID += "_em" // To ensure we don't overwrite real datasets
+
+		// NOTE: PIXL EM import - we clear everything before importing so we don't end up with eg images from a bad previous import
+		data.ClearBeforeSave = true
 		return data, filepath.Join(importPath, zipName, zipName), nil
 	}
 
@@ -243,8 +246,8 @@ func importEMData(creatorId string, rtt string, beamLocPath string, hkPath strin
 	product := "???"
 
 	// Use current date encoded as a test sol
-	// A=2017, 'A' is 65 ascii
-	sol := fmt.Sprintf("%v%v", string(65+time.Now().Year()-2017), time.Now().YearDay())
+	// A=2016, 'A' is 65 ascii
+	sol := fmt.Sprintf("%v%v", string(65+time.Now().Year()-2016), time.Now().YearDay())
 
 	ftype := "??" // PE
 	producer := "J"

--- a/api/dataimport/internal/converters/pixlfm/import.go
+++ b/api/dataimport/internal/converters/pixlfm/import.go
@@ -393,6 +393,9 @@ func (p PIXLFM) Import(importPath string, pseudoIntensityRangesPath string, data
 		log,
 	)
 
+	// Explicitly set to NOT clear before import - this way we should keep images around...
+	data.ClearBeforeSave = false
+
 	if err != nil {
 		return nil, "", err
 	}

--- a/api/dataimport/internal/dataConvertModels/models.go
+++ b/api/dataimport/internal/dataConvertModels/models.go
@@ -245,6 +245,10 @@ type OutputData struct {
 
 	// Beam generator version number
 	BeamVersion uint32
+
+	// ClearBeforeSave - As the name says, this flag can indicate from the importer that when saving this data
+	// we have to clear existing data for it. Mainly for images, do we want old ones to stick around incorrectly?
+	ClearBeforeSave bool
 }
 
 // EnsurePMC - allocates an item to store data for the given PMC if doesn't already exist


### PR DESCRIPTION
…s/def image/ownership from DB before saving new one. This is only enabled for PIXL EM imports now. Also modified test sol generation to start at A=2016 because that's what the UI implements, but I suspect they should both be set to 2017