### PR TITLE
Fixing uploading of imported files - we weren't including the scan id…

### DIFF
--- a/api/dataimport/import.go
+++ b/api/dataimport/import.go
@@ -23,6 +23,7 @@ package dataimport
 import (
 	"fmt"
 	"os"
+	"path"
 	"path/filepath"
 	"strconv"
 	"time"
@@ -227,7 +228,7 @@ func ImportFromLocalFileSystem(
 
 	// Finally, copy scan files to scans, and images to images
 	log.Infof("Copying generated dataset to bucket: %v...", datasetBucket)
-	err = fileaccess.CopyToBucket(remoteFS, data.DatasetID, outputScanPath, datasetBucket, filepaths.DatasetScansRoot, false, log)
+	err = fileaccess.CopyToBucket(remoteFS, outputScanPath, datasetBucket, path.Join(filepaths.DatasetScansRoot, data.DatasetID), false, log)
 	if err != nil {
 		return "", fmt.Errorf("Error when copying dataset to bucket: %v. Error: %v", datasetBucket, err)
 	}
@@ -235,7 +236,7 @@ func ImportFromLocalFileSystem(
 	log.Infof("Copying images to bucket: %v...", datasetBucket)
 	imagePath := filepath.Join(outputImagesPath, data.DatasetID)
 
-	err = fileaccess.CopyToBucket(remoteFS, data.DatasetID, imagePath, datasetBucket, filepaths.DatasetImagesRoot, false, log)
+	err = fileaccess.CopyToBucket(remoteFS, imagePath, datasetBucket, path.Join(filepaths.DatasetImagesRoot, data.DatasetID), false, log)
 	if err != nil {
 		return "", fmt.Errorf("Error when copying dataset to bucket: %v. Error: %v", datasetBucket, err)
 	}

--- a/api/endpoints/Image.go
+++ b/api/endpoints/Image.go
@@ -857,7 +857,7 @@ func saveImageDataAsPyramid(
 	// Write to S3 (need to use a multithreaded approach as it'd take way too long otherwise)
 	// Save the image we saved to local storage in chunks as one file to S3
 	s3Path := filepaths.GetImageFilePath(savePath)
-	return fileaccess.CopyToBucket(fs, "", localImageDataPath+"_files", bucket, s3Path, true, l)
+	return fileaccess.CopyToBucket(fs, localImageDataPath+"_files", bucket, s3Path, true, l)
 }
 
 func saveImageDataFromFile(fs fileaccess.FileAccess, bucket string, savePath string, localImageDataPath string) error {

--- a/core/fileaccess/s3.go
+++ b/core/fileaccess/s3.go
@@ -305,7 +305,7 @@ func ClearBucketDir(bucket string, s3Path string, remoteFS FileAccess, logger lo
 // Copies files to bucket
 // If preserveStructure is true, preserves directory structure from sourcePath.
 // If preserveStructure is false, copies all files flat (just filename, no subdirectories).
-func CopyToBucket(remoteFS FileAccess, datasetID string, sourcePath string, destBucket string, destPath string, preserveStructure bool, log logger.ILogger) error {
+func CopyToBucket(remoteFS FileAccess, sourcePath string, destBucket string, destPath string, preserveStructure bool, log logger.ILogger) error {
 	var uploadError error
 
 	localFS := FSAccess{}
@@ -320,9 +320,9 @@ func CopyToBucket(remoteFS FileAccess, datasetID string, sourcePath string, dest
 	numUploaders := 1
 	if totalCount > 10 {
 		numUploaders = 5
-		for w := 1; w <= numUploaders; w++ {
-			go uploadWorker(w, jobs, results)
-		}
+	}
+	for w := 1; w <= numUploaders; w++ {
+		go uploadWorker(w, jobs, results)
 	}
 
 	err := filepath.Walk(sourcePath, func(currentPath string, info os.FileInfo, err error) error {
@@ -363,7 +363,7 @@ func CopyToBucket(remoteFS FileAccess, datasetID string, sourcePath string, dest
 		return err
 	}
 
-	if numUploaders > 1 && uploadError == nil {
+	if numUploaders > 0 && uploadError == nil {
 		close(jobs)
 
 		// Check each upload for an error


### PR DESCRIPTION
… - not sure how this worked in prod before, we must have an old lambda deployed that's pre this change. This probably changed during image pyramid related importer changes