### PR TITLE
Fixed long standing email notification duplication bug - if users had…

### DIFF
--- a/api/ws/wsHelpers/ownership.go
+++ b/api/ws/wsHelpers/ownership.go
@@ -3,6 +3,7 @@ package wsHelpers
 import (
 	"context"
 	"fmt"
+	"sort"
 
 	"github.com/pixlise/core/v4/api/dbCollections"
 	"github.com/pixlise/core/v4/api/services"
@@ -303,7 +304,20 @@ func FindUserIdsFor(objectId string, mongoDB *mongo.Database) ([]string, error) 
 		return []string{}, err
 	}
 
-	return append(userIds, usersForGroups...), nil
+	// Make one list
+	userIds = append(userIds, usersForGroups...)
+
+	// Make them unique
+	uniqueUserIds := map[string]bool{}
+	for _, id := range userIds {
+		uniqueUserIds[id] = true
+	}
+
+	// Unique list now
+	userIds = utils.GetMapKeys(uniqueUserIds)
+	sort.Strings(userIds)
+
+	return userIds, nil
 }
 
 func GetUserIdsForGroup(groupIds []string, mongoDB *mongo.Database) ([]string, error) {


### PR DESCRIPTION
… access to a scan via multiple methods, eg being in 2 different user groups, or having a scan shared with them as a user and also access via a group, they got duplicate emails. Now the user id list for emails is checked for unique-ness and sorted so notifications will be more controlled